### PR TITLE
Updating lagging references to match renamed module

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-exclude: pegasus/templates/*
+exclude: pegasus_cli/templates/*
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.2.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,4 +30,4 @@ dev = ["pytest", "ruff", "pre-commit"]
 where = ["."]
 
 [tool.setuptools.package-data]
-pegasus = ["templates/**/*"]
+pegasus_cli = ["templates/**/*"]


### PR DESCRIPTION
Commits a08bbe6 and aa4fa19 renamed the module from `pegasus` to `pegasus_cli` and updated pyproject.toml accordingly. However, I believe that update broke the package because it missed one place pyproject.toml needed to be updated. The pre-commit config file needs to be updated as well.

In v0.4 (before the rename commits), the `/templates` directory was included in the published package. See code [here](https://socket.dev/pypi/package/pegasus-cli/files/0.4/tar-gz/pegasus_cli-0.4/pegasus). In v0.5 (after that commit), the `/templates` directory was not present. See code [here](https://socket.dev/pypi/package/pegasus-cli/files/0.5/tar-gz/pegasus_cli-0.5/pegasus_cli).

Now, when I install v0.5 and attempt to run `pegasus startapp todo` I get:

```FileNotFoundError: [Errno 2] No such file or directory: '/Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/site-packages/pegasus_cli/templates/app_template'```

And indeed the `/templates` directory is missing from my installation.

I have not tested this fix, but at minimum this change should presumably be made (since the pegasus/templates directory has been renamed to pegasus_cli/templates). 

If this doesn't fix the template folder exclusion, I am not sure what the fix is, but believe it has to do with the renaming of the module folder.