### PR TITLE
lint fixes

### DIFF
--- a/pegasus_cli/generate.py
+++ b/pegasus_cli/generate.py
@@ -24,6 +24,6 @@ def render_cookiecutter(
         overwrite_if_exists=True,
         skip_if_file_exists=False,
         output_dir=output_dir,
-        accept_hooks=False,
+        accept_hooks=True,
         keep_project_on_failure=True,
     )

--- a/pegasus_cli/templates/app_template/hooks/post_gen_project.py
+++ b/pegasus_cli/templates/app_template/hooks/post_gen_project.py
@@ -1,0 +1,24 @@
+import os
+import pathlib
+import shutil
+from os import remove
+
+project_dir = os.getcwd()
+
+<% if not model_names %>
+remove(os.path.join(project_dir, "forms.py"))
+<% endif %>
+
+def _check_before_remove(path):
+    if not pathlib.Path(path).is_relative_to(project_dir):
+        raise Exception(f"Trying to remove a file that isn't in the project directory: {path} not in {project_dir}")
+
+
+# see https://github.com/audreyr/cookiecutter/issues/723 for more on this approach
+def remove(filepath):
+    _check_before_remove(filepath)
+
+    if os.path.isfile(filepath):
+        os.remove(filepath)
+    elif os.path.isdir(filepath):
+        shutil.rmtree(filepath)

--- a/pegasus_cli/templates/app_template/{{cookiecutter.app_name}}/models.py
+++ b/pegasus_cli/templates/app_template/{{cookiecutter.app_name}}/models.py
@@ -1,7 +1,9 @@
+<%- if model_names %>
+from django.conf import settings
+<%- endif %>
 from django.db import models<% if not model_names %>  # noqa<% endif %>
 from django.urls import reverse
 <%- if model_names %>
-from django.conf import settings
 <%- if base_model %>
 
 from << base_model_module >> import << base_model_class >>

--- a/pegasus_cli/templates/app_template/{{cookiecutter.app_name}}/models.py
+++ b/pegasus_cli/templates/app_template/{{cookiecutter.app_name}}/models.py
@@ -1,4 +1,4 @@
-<%- if model_names %>
+<% if model_names -%>
 from django.conf import settings
 <%- endif %>
 from django.db import models<% if not model_names %>  # noqa<% endif %>

--- a/pegasus_cli/templates/app_template/{{cookiecutter.app_name}}/models.py
+++ b/pegasus_cli/templates/app_template/{{cookiecutter.app_name}}/models.py
@@ -2,8 +2,8 @@
 from django.conf import settings
 <%- endif %>
 from django.db import models<% if not model_names %>  # noqa<% endif %>
-from django.urls import reverse
 <%- if model_names %>
+from django.urls import reverse
 <%- if base_model %>
 
 from << base_model_module >> import << base_model_class >>

--- a/pegasus_cli/templates/app_template/{{cookiecutter.app_name}}/views.py
+++ b/pegasus_cli/templates/app_template/{{cookiecutter.app_name}}/views.py
@@ -1,4 +1,4 @@
-<%- if model_names %>
+<% if model_names -%>
 from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
 from django.http.response import HttpResponseRedirect
 from django.shortcuts import get_object_or_404, render

--- a/pegasus_cli/templates/app_template/{{cookiecutter.app_name}}/views.py
+++ b/pegasus_cli/templates/app_template/{{cookiecutter.app_name}}/views.py
@@ -10,7 +10,8 @@ from django.views.decorators.http import require_POST
 <%- endif %>
 
 from << view_decorator_module >> import << view_decorator_function >>
-<% if model_names %>
+<%- if model_names %>
+
 from .forms import <% for model in model_names %><< model >>Form<% if not loop.last %>, <% endif %><% endfor %>
 from .models import <% for model in model_names %><< model >><% if not loop.last %>, <% endif %><% endfor %>
 

--- a/pegasus_cli/templates/app_template/{{cookiecutter.app_name}}/views.py
+++ b/pegasus_cli/templates/app_template/{{cookiecutter.app_name}}/views.py
@@ -1,6 +1,5 @@
-from << view_decorator_module >> import << view_decorator_function >>
 <%- if model_names %>
-from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
+from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
 from django.http.response import HttpResponseRedirect
 from django.shortcuts import get_object_or_404, render
 <%- endif %>
@@ -8,9 +7,12 @@ from django.template.response import TemplateResponse
 <%- if model_names %>
 from django.urls import reverse
 from django.views.decorators.http import require_POST
+<%- endif %>
 
-from .models import <% for model in model_names %><< model >><% if not loop.last %>, <% endif %><% endfor %>
+from << view_decorator_module >> import << view_decorator_function >>
+<% if model_names %>
 from .forms import <% for model in model_names %><< model >>Form<% if not loop.last %>, <% endif %><% endfor %>
+from .models import <% for model in model_names %><< model >><% if not loop.last %>, <% endif %><% endfor %>
 
 # A reasonable value for pagination would be 10 or 20 entries per page.
 # Here we use 4 (a very low value), so we can show off the pagination using fewer items

--- a/pegasus_cli/templates/app_template/{{cookiecutter.app_name}}/views.py
+++ b/pegasus_cli/templates/app_template/{{cookiecutter.app_name}}/views.py
@@ -25,10 +25,7 @@ PAGINATE_BY = 4
 
 @<< view_decorator_function >>
 def home(request<< extra_view_args >>):
-    if request.htmx:
-        template = "<< app_name >>/<< app_name >>_home.html#page-content"
-    else:
-        template = "<< app_name >>/<< app_name >>_home.html"
+    template = "<< app_name >>/<< app_name >>_home.html#page-content" if request.htmx else "<< app_name >>/<< app_name >>_home.html"
 
     return TemplateResponse(request, template, {"active_tab": "<< app_name >>"})
 <%- for model_name in model_names %>
@@ -76,10 +73,7 @@ def << model_name | lower >>_detail(request<< extra_view_args >>, pk):
     context["active_tab"] = "<< app_name >>"
     context["object"] = << model_name >>.objects.get(id=pk)
 
-    if request.htmx:
-        template = "<< app_name >>/<< model_name | lower >>_detail.html#page-content"
-    else:
-        template = "<< app_name >>/<< model_name | lower >>_detail.html"
+    template = "<< app_name >>/<< model_name | lower >>_detail.html#page-content" if request.htmx else "<< app_name >>/<< model_name | lower >>_detail.html"
 
     return render(request, template, context)
 
@@ -98,10 +92,7 @@ def << model_name | lower >>_create(request<< extra_view_args >>):
         instance.save()
         return HttpResponseRedirect(reverse("<< app_name >>:<< model_name | lower >>_list"<% if extra_view_param %>, kwargs={"<< extra_view_param >>": << extra_view_param_value >>}<% endif %>))
 
-    if request.htmx:
-        template = "<< app_name >>/<< model_name | lower >>_form.html#page-content"
-    else:
-        template = "<< app_name >>/<< model_name | lower >>_form.html"
+    template = "<< app_name >>/<< model_name | lower >>_form.html#page-content" if request.htmx else "<< app_name >>/<< model_name | lower >>_form.html"
 
     context["active_tab"] = "<< app_name >>"
     context["form"] = form
@@ -118,10 +109,7 @@ def << model_name | lower >>_update(request<< extra_view_args >>, pk):
         form.save()
         return HttpResponseRedirect(reverse("<< app_name>>:<< model_name | lower >>_detail", kwargs={<% if extra_view_param %>"<< extra_view_param >>": << extra_view_param_value >>, <% endif %>"pk": pk}))
 
-    if request.htmx:
-        template = "<< app_name >>/<< model_name | lower >>_form.html#page-content"
-    else:
-        template = "<< app_name >>/<< model_name | lower >>_form.html"
+    template = "<< app_name >>/<< model_name | lower >>_form.html#page-content" if request.htmx else "<< app_name >>/<< model_name | lower >>_form.html"
     context["active_tab"] = "<< app_name >>"
     context["form"] = form
     context["object"] = obj


### PR DESCRIPTION
https://trello.com/c/7S0EAYDj

This fixes ruff lint and formatting for files produced with and without models.

@czue what about running `ruff format` after app generation (if ruff is installed)?

There are 2 remaining formatting changes applied when running `ruff format` on an app generated without models but those are less important and harder to fix:


```diff
2025-05-19 11:37:09 (.venv) (sk/tmp *$) ~/src/wedding_plan $ d
diff --git a/apps/todos/models.py b/apps/todos/models.py
index 533add85..9d57c559 100644
--- a/apps/todos/models.py
+++ b/apps/todos/models.py
@@ -1,5 +1,3 @@
-
 from django.db import models  # noqa
 
 # Create your models here.
-
diff --git a/apps/todos/views.py b/apps/todos/views.py
index 010dc401..bc09ffa0 100644
--- a/apps/todos/views.py
+++ b/apps/todos/views.py
@@ -1,4 +1,3 @@
-
 from django.template.response import TemplateResponse
 
 from apps.teams.decorators import login_and_team_required
```