### PR TITLE
Move dev deps from optional-dependencies to dependency-groups

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ CI = "https://github.com/saaspegasus/pegasus-cli/actions"
 [project.entry-points.console_scripts]
 pegasus = "pegasus_cli.cli:cli"
 
-[project.optional-dependencies]
+[dependency-groups]
 dev = ["pytest", "ruff", "pre-commit"]
 
 [tool.setuptools.packages.find]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
 [project]
 name = "pegasus-cli"
 version = "0.12"

--- a/uv.lock
+++ b/uv.lock
@@ -507,7 +507,7 @@ wheels = [
 [[package]]
 name = "pegasus-cli"
 version = "0.12"
-source = { virtual = "." }
+source = { editable = "." }
 dependencies = [
     { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "click", version = "8.3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },

--- a/uv.lock
+++ b/uv.lock
@@ -516,7 +516,7 @@ dependencies = [
     { name = "rich" },
 ]
 
-[package.optional-dependencies]
+[package.dev-dependencies]
 dev = [
     { name = "pre-commit", version = "4.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "pre-commit", version = "4.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
@@ -529,13 +529,16 @@ dev = [
 requires-dist = [
     { name = "click" },
     { name = "cookiecutter" },
-    { name = "pre-commit", marker = "extra == 'dev'" },
-    { name = "pytest", marker = "extra == 'dev'" },
     { name = "requests" },
     { name = "rich" },
-    { name = "ruff", marker = "extra == 'dev'" },
 ]
-provides-extras = ["dev"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pre-commit" },
+    { name = "pytest" },
+    { name = "ruff" },
+]
 
 [[package]]
 name = "platformdirs"


### PR DESCRIPTION
uv automatically includes the dev dependency group, fixing CI where pytest wasn't found because optional extras aren't installed by default.