### PR TITLE
Add pegasus server create for Hetzner provisioning

### DIFF
--- a/docs/plans/2026-02-27-hetzner-server-provisioning-design.md
+++ b/docs/plans/2026-02-27-hetzner-server-provisioning-design.md
@@ -1,0 +1,105 @@
+# Hetzner Server Provisioning Design
+
+## Summary
+
+Add a `pegasus server create` command that provisions a Hetzner Cloud server
+configured for Kamal deployments. Uses sensible defaults with optional flag
+overrides, auto-detects SSH keys, and optionally updates Kamal config if detected.
+
+## Command Structure
+
+```
+pegasus server create <name>   # Provision a new Hetzner server
+```
+
+Future commands (not in v1): `server list`, `server destroy`.
+
+## Detailed Flow
+
+### 1. Hetzner API Token
+
+**Resolution order** (same pattern as Pegasus API key):
+1. `HETZNER_API_TOKEN` env var
+2. `~/.pegasus/hetzner_credentials` file
+
+If neither exists, print instructions for creating a token in the
+Hetzner Cloud Console (https://console.hetzner.cloud → project → Security → API Tokens),
+prompt for input, validate it with an API call, and save to `~/.pegasus/hetzner_credentials`
+with 0o600 permissions.
+
+### 2. SSH Key Detection
+
+Scan `~/.ssh/` for `*.pub` files.
+
+- **No keys found**: Print error explaining how to generate one (`ssh-keygen -t ed25519`),
+  then exit with non-zero status. Do not create the server.
+- **One key found**: Use it automatically.
+- **Multiple keys found**: Prompt user to pick one.
+
+Once a key is selected, check if it's already uploaded to Hetzner (match by public key content).
+If not, upload it with a name derived from the filename (e.g. `id_ed25519`).
+
+### 3. Server Creation
+
+**Required argument:**
+- `name` — server name (positional arg)
+
+**Defaults with optional flag overrides:**
+
+| Parameter | Default | Flag |
+|-----------|---------|------|
+| Server type | `cx22` (2 vCPU, 4GB, ~€4/mo) | `--server-type` |
+| Image | `ubuntu-24.04` | `--image` |
+| Location | `nbg1` (Nuremberg) | `--location` |
+
+Create the server via hcloud SDK. Show a Rich spinner while waiting for
+the server status to become `running`.
+
+### 4. Output
+
+Print:
+- Server IP address
+- SSH connection command: `ssh root@<ip>`
+- Server name and type summary
+
+### 5. Kamal Config Detection
+
+Check if `config/deploy.yml` exists in the current directory.
+
+- **If found**: Parse the YAML, find the `servers` → `web` section, and update
+  the IP address. Show the user what changed.
+- **If not found**: Print a note linking to Kamal deployment docs
+  (https://docs.saaspegasus.com/deployment/kamal/).
+
+## New Files
+
+- `pegasus_cli/server.py` — `server` command group with `create` subcommand
+- `pegasus_cli/hetzner_client.py` — Hetzner API wrapper using hcloud SDK
+- `tests/test_server.py` — tests for the server command
+- `tests/test_hetzner_client.py` — tests for the Hetzner client
+
+## Modified Files
+
+- `pegasus_cli/cli.py` — register `server` command group
+- `pegasus_cli/credentials.py` — add Hetzner credential helpers
+- `pyproject.toml` — add `hcloud` dependency, bump Python to >=3.10
+
+## Dependencies
+
+- Add `hcloud` as a regular dependency
+- Bump `requires-python` from `>=3.9` to `>=3.10`
+
+## Credential Management
+
+Add to `credentials.py`:
+- `HETZNER_CREDENTIALS_FILE = PEGASUS_DIR / "hetzner_credentials"`
+- `get_hetzner_api_key()` — same pattern as `get_api_key()` but for Hetzner token
+- `save_hetzner_api_key(key)` — same pattern as `save_api_key()`
+
+## Error Handling
+
+- Invalid/missing Hetzner token → prompt to enter one
+- No SSH keys in ~/.ssh → error with ssh-keygen instructions, exit
+- Server creation failure → display Hetzner API error message
+- Network errors → display connection error
+- Kamal config parse failure → skip config update, print manual instructions

--- a/docs/plans/2026-02-27-hetzner-server-provisioning.md
+++ b/docs/plans/2026-02-27-hetzner-server-provisioning.md
@@ -1,0 +1,769 @@
+# Hetzner Server Provisioning Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add `pegasus server create` command that provisions a Hetzner Cloud server and optionally updates Kamal deploy config.
+
+**Architecture:** New `server` command group using Click, backed by an `hetzner_client.py` module wrapping the `hcloud` SDK. Hetzner credentials follow the same pattern as Pegasus credentials (env var > file). SSH keys are auto-detected from `~/.ssh/`.
+
+**Tech Stack:** Click (CLI), hcloud SDK (Hetzner API), Rich (terminal UI), PyYAML (Kamal config parsing)
+
+---
+
+### Task 1: Add hcloud dependency and bump Python version
+
+**Files:**
+- Modify: `pyproject.toml`
+
+**Step 1: Update pyproject.toml**
+
+In `pyproject.toml`, change `requires-python` from `">=3.9"` to `">=3.10"`, and add `"hcloud"` and `"pyyaml"` to the `dependencies` list:
+
+```toml
+requires-python = ">=3.10"
+dependencies = [
+    "click",
+    "cookiecutter",
+    "hcloud",
+    "pyyaml",
+    "requests",
+    "rich",
+]
+```
+
+**Step 2: Install dependencies**
+
+Run: `uv sync`
+Expected: Installs hcloud and pyyaml successfully.
+
+**Step 3: Verify hcloud imports**
+
+Run: `uv run python -c "import hcloud; print(hcloud.__version__)"`
+Expected: Prints version number without errors.
+
+**Step 4: Commit**
+
+```bash
+git add pyproject.toml uv.lock
+git commit -m "Add hcloud and pyyaml dependencies, bump Python to 3.10+"
+```
+
+---
+
+### Task 2: Add Hetzner credential helpers
+
+**Files:**
+- Modify: `pegasus_cli/credentials.py`
+- Test: `tests/test_credentials.py`
+
+**Step 1: Write the failing tests**
+
+Add to `tests/test_credentials.py`:
+
+```python
+from pegasus_cli.credentials import (
+    get_hetzner_api_key,
+    save_hetzner_api_key,
+)
+
+
+def test_save_and_read_hetzner_api_key(tmp_path, monkeypatch):
+    creds_dir = tmp_path / ".pegasus"
+    creds_file = creds_dir / "hetzner_credentials"
+    monkeypatch.setattr("pegasus_cli.credentials.CREDENTIALS_DIR", creds_dir)
+    monkeypatch.setattr("pegasus_cli.credentials.HETZNER_CREDENTIALS_FILE", creds_file)
+    monkeypatch.delenv("HETZNER_API_TOKEN", raising=False)
+
+    assert get_hetzner_api_key() is None
+
+    save_hetzner_api_key("hetzner-test-key")
+    assert get_hetzner_api_key() == "hetzner-test-key"
+    assert oct(creds_file.stat().st_mode)[-3:] == "600"
+
+
+def test_hetzner_env_var_takes_precedence(tmp_path, monkeypatch):
+    creds_dir = tmp_path / ".pegasus"
+    creds_file = creds_dir / "hetzner_credentials"
+    monkeypatch.setattr("pegasus_cli.credentials.CREDENTIALS_DIR", creds_dir)
+    monkeypatch.setattr("pegasus_cli.credentials.HETZNER_CREDENTIALS_FILE", creds_file)
+
+    save_hetzner_api_key("file-key")
+    monkeypatch.setenv("HETZNER_API_TOKEN", "env-key")
+    assert get_hetzner_api_key() == "env-key"
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_credentials.py -v -k "hetzner"`
+Expected: FAIL with ImportError (functions don't exist yet).
+
+**Step 3: Implement credential helpers**
+
+Add to `pegasus_cli/credentials.py`:
+
+```python
+HETZNER_CREDENTIALS_FILE = CREDENTIALS_DIR / "hetzner_credentials"
+HETZNER_ENV_VAR = "HETZNER_API_TOKEN"
+
+
+def get_hetzner_api_key() -> str | None:
+    """Get the Hetzner API token, checking env var first, then credentials file."""
+    api_key = os.environ.get(HETZNER_ENV_VAR)
+    if api_key:
+        return api_key.strip()
+    if HETZNER_CREDENTIALS_FILE.exists():
+        return HETZNER_CREDENTIALS_FILE.read_text().strip()
+    return None
+
+
+def save_hetzner_api_key(api_key: str) -> Path:
+    """Save Hetzner API token to ~/.pegasus/hetzner_credentials. Returns the file path."""
+    CREDENTIALS_DIR.mkdir(parents=True, exist_ok=True)
+    HETZNER_CREDENTIALS_FILE.write_text(api_key.strip() + "\n")
+    HETZNER_CREDENTIALS_FILE.chmod(0o600)
+    return HETZNER_CREDENTIALS_FILE
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_credentials.py -v`
+Expected: All pass (both existing and new).
+
+**Step 5: Commit**
+
+```bash
+git add pegasus_cli/credentials.py tests/test_credentials.py
+git commit -m "Add Hetzner credential helpers to credentials module"
+```
+
+---
+
+### Task 3: Create Hetzner client module
+
+**Files:**
+- Create: `pegasus_cli/hetzner_client.py`
+- Create: `tests/test_hetzner_client.py`
+
+The Hetzner client wraps the hcloud SDK to provide three operations:
+1. Validate a token (list servers as a check)
+2. Ensure an SSH key exists on Hetzner (find by content or upload)
+3. Create a server
+
+**Step 1: Write the failing tests**
+
+Create `tests/test_hetzner_client.py`:
+
+```python
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from pegasus_cli.hetzner_client import HetznerClient
+
+
+@pytest.fixture
+def mock_hcloud():
+    """Patch hcloud.Client and return the mock instance."""
+    with patch("pegasus_cli.hetzner_client.hcloud.Client") as mock_cls:
+        client = HetznerClient("test-token")
+        yield client, mock_cls.return_value
+
+
+class TestValidateToken:
+    def test_validate_success(self, mock_hcloud):
+        client, mock_api = mock_hcloud
+        mock_api.servers.get_all.return_value = []
+        # Should not raise
+        client.validate_token()
+
+    def test_validate_failure(self, mock_hcloud):
+        client, mock_api = mock_hcloud
+        mock_api.servers.get_all.side_effect = Exception("Unauthorized")
+        with pytest.raises(Exception):
+            client.validate_token()
+
+
+class TestEnsureSshKey:
+    def test_key_already_exists(self, mock_hcloud):
+        client, mock_api = mock_hcloud
+        existing_key = MagicMock()
+        existing_key.name = "my-key"
+        existing_key.public_key = "ssh-ed25519 AAAA testkey"
+        mock_api.ssh_keys.get_all.return_value = [existing_key]
+
+        result = client.ensure_ssh_key("my-key", "ssh-ed25519 AAAA testkey")
+        assert result.name == "my-key"
+        mock_api.ssh_keys.create.assert_not_called()
+
+    def test_key_uploaded_when_missing(self, mock_hcloud):
+        client, mock_api = mock_hcloud
+        mock_api.ssh_keys.get_all.return_value = []
+        new_key = MagicMock()
+        new_key.name = "my-key"
+        mock_api.ssh_keys.create.return_value = new_key
+
+        result = client.ensure_ssh_key("my-key", "ssh-ed25519 AAAA testkey")
+        assert result.name == "my-key"
+        mock_api.ssh_keys.create.assert_called_once_with(
+            name="my-key", public_key="ssh-ed25519 AAAA testkey"
+        )
+
+
+class TestCreateServer:
+    def test_create_server(self, mock_hcloud):
+        client, mock_api = mock_hcloud
+        mock_server = MagicMock()
+        mock_server.public_net.ipv4.ip = "1.2.3.4"
+        mock_server.name = "my-server"
+        mock_server.server_type.name = "cx22"
+
+        mock_response = MagicMock()
+        mock_response.server = mock_server
+        mock_response.action = MagicMock()
+        mock_api.servers.create.return_value = mock_response
+
+        ssh_key = MagicMock()
+        result = client.create_server(
+            name="my-server",
+            ssh_key=ssh_key,
+            server_type="cx22",
+            image="ubuntu-24.04",
+            location="nbg1",
+        )
+        assert result.server.public_net.ipv4.ip == "1.2.3.4"
+        mock_api.servers.create.assert_called_once()
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_hetzner_client.py -v`
+Expected: FAIL with ModuleNotFoundError.
+
+**Step 3: Implement the Hetzner client**
+
+Create `pegasus_cli/hetzner_client.py`:
+
+```python
+import hcloud
+from hcloud.images import Image
+from hcloud.locations import Location
+from hcloud.server_types import ServerType
+from hcloud.ssh_keys import SSHKey
+
+
+class HetznerClient:
+    def __init__(self, token: str):
+        self.client = hcloud.Client(token=token)
+
+    def validate_token(self) -> None:
+        """Validate the token by making an API call. Raises on failure."""
+        self.client.servers.get_all()
+
+    def ensure_ssh_key(self, name: str, public_key: str) -> SSHKey:
+        """Find an existing SSH key by content, or upload it.
+
+        Matches by public key content (not name) to avoid duplicates.
+        """
+        existing_keys = self.client.ssh_keys.get_all()
+        for key in existing_keys:
+            if key.public_key.strip() == public_key.strip():
+                return key
+
+        return self.client.ssh_keys.create(name=name, public_key=public_key)
+
+    def create_server(
+        self,
+        name: str,
+        ssh_key: SSHKey,
+        server_type: str = "cx22",
+        image: str = "ubuntu-24.04",
+        location: str = "nbg1",
+    ):
+        """Create a Hetzner server. Returns the create response (has .server and .action)."""
+        return self.client.servers.create(
+            name=name,
+            server_type=ServerType(name=server_type),
+            image=Image(name=image),
+            location=Location(name=location),
+            ssh_keys=[ssh_key],
+        )
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_hetzner_client.py -v`
+Expected: All pass.
+
+**Step 5: Commit**
+
+```bash
+git add pegasus_cli/hetzner_client.py tests/test_hetzner_client.py
+git commit -m "Add Hetzner client module wrapping hcloud SDK"
+```
+
+---
+
+### Task 4: Create the server command group with `create` subcommand
+
+**Files:**
+- Create: `pegasus_cli/server.py`
+- Create: `tests/test_server.py`
+- Modify: `pegasus_cli/cli.py`
+
+This is the main task. The `server create` command ties together credentials, SSH key detection, server creation, and Kamal config updates.
+
+**Step 1: Write the failing tests**
+
+Create `tests/test_server.py`:
+
+```python
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from pegasus_cli.cli import cli
+
+
+def _mock_hetzner_client():
+    """Create a mock HetznerClient."""
+    client = MagicMock()
+    mock_server = MagicMock()
+    mock_server.public_net.ipv4.ip = "1.2.3.4"
+    mock_server.name = "my-server"
+    mock_server.server_type.name = "cx22"
+
+    mock_response = MagicMock()
+    mock_response.server = mock_server
+    mock_response.action = MagicMock()
+    client.create_server.return_value = mock_response
+
+    ssh_key = MagicMock()
+    ssh_key.name = "id_ed25519"
+    client.ensure_ssh_key.return_value = ssh_key
+
+    return client
+
+
+class TestServerCreate:
+    @patch("pegasus_cli.server.HetznerClient")
+    @patch("pegasus_cli.server.get_hetzner_api_key", return_value="test-token")
+    @patch("pegasus_cli.server._find_ssh_keys")
+    def test_create_basic(self, mock_find_keys, mock_get_key, mock_client_cls):
+        mock_find_keys.return_value = [
+            (Path("~/.ssh/id_ed25519.pub"), "ssh-ed25519 AAAA testkey")
+        ]
+        mock_client_cls.return_value = _mock_hetzner_client()
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["server", "create", "my-server"])
+        assert result.exit_code == 0
+        assert "1.2.3.4" in result.output
+        assert "ssh root@1.2.3.4" in result.output
+
+    @patch("pegasus_cli.server.HetznerClient")
+    @patch("pegasus_cli.server.get_hetzner_api_key", return_value="test-token")
+    @patch("pegasus_cli.server._find_ssh_keys")
+    def test_create_with_flags(self, mock_find_keys, mock_get_key, mock_client_cls):
+        mock_find_keys.return_value = [
+            (Path("~/.ssh/id_ed25519.pub"), "ssh-ed25519 AAAA testkey")
+        ]
+        client = _mock_hetzner_client()
+        mock_client_cls.return_value = client
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "server", "create", "my-server",
+                "--server-type", "cx32",
+                "--image", "ubuntu-22.04",
+                "--location", "fsn1",
+            ],
+        )
+        assert result.exit_code == 0
+        client.create_server.assert_called_once_with(
+            name="my-server",
+            ssh_key=client.ensure_ssh_key.return_value,
+            server_type="cx32",
+            image="ubuntu-22.04",
+            location="fsn1",
+        )
+
+    @patch("pegasus_cli.server._find_ssh_keys")
+    def test_create_no_api_key_prompts(self, mock_find_keys):
+        """When no Hetzner token is found, prompt the user."""
+        mock_find_keys.return_value = [
+            (Path("~/.ssh/id_ed25519.pub"), "ssh-ed25519 AAAA testkey")
+        ]
+        runner = CliRunner()
+        with patch("pegasus_cli.server.get_hetzner_api_key", return_value=None):
+            with patch("pegasus_cli.server.HetznerClient") as mock_cls:
+                mock_cls.return_value = _mock_hetzner_client()
+                with patch("pegasus_cli.server.save_hetzner_api_key") as mock_save:
+                    mock_save.return_value = Path("~/.pegasus/hetzner_credentials")
+                    result = runner.invoke(
+                        cli,
+                        ["server", "create", "my-server"],
+                        input="my-hetzner-token\n",
+                    )
+                    assert result.exit_code == 0
+                    mock_save.assert_called_once_with("my-hetzner-token")
+
+    @patch("pegasus_cli.server.get_hetzner_api_key", return_value="test-token")
+    @patch("pegasus_cli.server._find_ssh_keys")
+    def test_create_no_ssh_keys(self, mock_find_keys, mock_get_key):
+        mock_find_keys.return_value = []
+        runner = CliRunner()
+        result = runner.invoke(cli, ["server", "create", "my-server"])
+        assert result.exit_code != 0
+        assert "ssh-keygen" in result.output
+
+    @patch("pegasus_cli.server.HetznerClient")
+    @patch("pegasus_cli.server.get_hetzner_api_key", return_value="test-token")
+    @patch("pegasus_cli.server._find_ssh_keys")
+    def test_create_multiple_ssh_keys_prompts(
+        self, mock_find_keys, mock_get_key, mock_client_cls
+    ):
+        mock_find_keys.return_value = [
+            (Path("~/.ssh/id_ed25519.pub"), "ssh-ed25519 AAAA key1"),
+            (Path("~/.ssh/id_rsa.pub"), "ssh-rsa BBBB key2"),
+        ]
+        mock_client_cls.return_value = _mock_hetzner_client()
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["server", "create", "my-server"], input="1\n")
+        assert result.exit_code == 0
+        assert "1.2.3.4" in result.output
+
+    @patch("pegasus_cli.server.HetznerClient")
+    @patch("pegasus_cli.server.get_hetzner_api_key", return_value="test-token")
+    @patch("pegasus_cli.server._find_ssh_keys")
+    def test_create_updates_kamal_config(
+        self, mock_find_keys, mock_get_key, mock_client_cls
+    ):
+        mock_find_keys.return_value = [
+            (Path("~/.ssh/id_ed25519.pub"), "ssh-ed25519 AAAA testkey")
+        ]
+        mock_client_cls.return_value = _mock_hetzner_client()
+
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            # Create a Kamal deploy config
+            Path("config").mkdir()
+            Path("config/deploy.yml").write_text(
+                "servers:\n  - <IP-ADDRESS>\n"
+            )
+            result = runner.invoke(cli, ["server", "create", "my-server"])
+            assert result.exit_code == 0
+            # Verify the config was updated
+            config = Path("config/deploy.yml").read_text()
+            assert "1.2.3.4" in config
+            assert "<IP-ADDRESS>" not in config
+
+    @patch("pegasus_cli.server.HetznerClient")
+    @patch("pegasus_cli.server.get_hetzner_api_key", return_value="test-token")
+    @patch("pegasus_cli.server._find_ssh_keys")
+    def test_create_no_kamal_config_shows_docs_link(
+        self, mock_find_keys, mock_get_key, mock_client_cls
+    ):
+        mock_find_keys.return_value = [
+            (Path("~/.ssh/id_ed25519.pub"), "ssh-ed25519 AAAA testkey")
+        ]
+        mock_client_cls.return_value = _mock_hetzner_client()
+
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            result = runner.invoke(cli, ["server", "create", "my-server"])
+            assert result.exit_code == 0
+            assert "docs.saaspegasus.com" in result.output
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_server.py -v`
+Expected: FAIL with ModuleNotFoundError.
+
+**Step 3: Implement the server command**
+
+Create `pegasus_cli/server.py`:
+
+```python
+import sys
+from pathlib import Path
+
+import click
+import yaml
+from rich.console import Console
+
+from .credentials import get_hetzner_api_key, save_hetzner_api_key
+from .hetzner_client import HetznerClient
+
+KAMAL_CONFIG_PATH = Path("config/deploy.yml")
+
+
+def _find_ssh_keys() -> list[tuple[Path, str]]:
+    """Find SSH public keys in ~/.ssh/. Returns list of (path, content) tuples."""
+    ssh_dir = Path.home() / ".ssh"
+    if not ssh_dir.exists():
+        return []
+    keys = []
+    for pub_file in sorted(ssh_dir.glob("*.pub")):
+        try:
+            content = pub_file.read_text().strip()
+            if content:
+                keys.append((pub_file, content))
+        except OSError:
+            continue
+    return keys
+
+
+def _get_or_prompt_hetzner_token() -> str:
+    """Get Hetzner token from env/file, or prompt the user."""
+    token = get_hetzner_api_key()
+    if token:
+        return token
+
+    console = Console(file=sys.stdout)
+    console.print(
+        "\n[bold]No Hetzner API token found.[/bold]\n"
+        "\nTo create one:\n"
+        "  1. Go to https://console.hetzner.cloud\n"
+        "  2. Select your project\n"
+        "  3. Go to Security → API Tokens\n"
+        "  4. Generate a new token with Read & Write permissions\n"
+    )
+    token = click.prompt("Enter your Hetzner API token", hide_input=True)
+    if not token.strip():
+        raise click.ClickException("API token cannot be empty.")
+
+    # Validate the token
+    client = HetznerClient(token.strip())
+    try:
+        with console.status("Verifying token..."):
+            client.validate_token()
+    except Exception:
+        raise click.ClickException(
+            "Token validation failed. Please check your token and try again."
+        )
+
+    path = save_hetzner_api_key(token)
+    click.echo(f"Token saved to {path}")
+    return token.strip()
+
+
+def _select_ssh_key(keys: list[tuple[Path, str]]) -> tuple[Path, str]:
+    """Select an SSH key from the list. Prompts if multiple."""
+    if len(keys) == 1:
+        click.echo(f"Using SSH key: {keys[0][0].name}")
+        return keys[0]
+
+    click.echo("Multiple SSH keys found:")
+    for i, (path, _) in enumerate(keys, 1):
+        click.echo(f"  {i}. {path.name}")
+
+    choice = click.prompt(
+        "Select a key",
+        type=click.IntRange(1, len(keys)),
+    )
+    return keys[choice - 1]
+
+
+def _update_kamal_config(ip_address: str) -> bool:
+    """Update config/deploy.yml with the server IP if it exists.
+
+    Handles both simple list format and placeholder format:
+      servers:
+        - <IP-ADDRESS>
+      servers:
+        - 0.0.0.0
+
+    Returns True if config was updated, False otherwise.
+    """
+    if not KAMAL_CONFIG_PATH.exists():
+        return False
+
+    try:
+        content = KAMAL_CONFIG_PATH.read_text()
+        data = yaml.safe_load(content)
+    except Exception:
+        return False
+
+    if not isinstance(data, dict) or "servers" not in data:
+        return False
+
+    servers = data["servers"]
+
+    # Simple list format: servers: [ip1, ip2]
+    if isinstance(servers, list):
+        updated = False
+        for i, server in enumerate(servers):
+            if isinstance(server, str) and _is_placeholder_ip(server):
+                servers[i] = ip_address
+                updated = True
+        if updated:
+            with open(KAMAL_CONFIG_PATH, "w") as f:
+                yaml.dump(data, f, default_flow_style=False)
+            return True
+
+    # Role-based format: servers: {web: [ip1, ip2]}
+    if isinstance(servers, dict):
+        updated = False
+        for role, hosts in servers.items():
+            if isinstance(hosts, list):
+                for i, host in enumerate(hosts):
+                    if isinstance(host, str) and _is_placeholder_ip(host):
+                        hosts[i] = ip_address
+                        updated = True
+        if updated:
+            with open(KAMAL_CONFIG_PATH, "w") as f:
+                yaml.dump(data, f, default_flow_style=False)
+            return True
+
+    return False
+
+
+def _is_placeholder_ip(value: str) -> bool:
+    """Check if a server value looks like a placeholder."""
+    placeholders = {"<IP-ADDRESS>", "<ip-address>", "0.0.0.0", "<YOUR-IP>", "<your-ip>"}
+    return value.strip() in placeholders
+
+
+# --- CLI commands ---
+
+
+@click.group()
+def server():
+    """Manage cloud servers."""
+
+
+@server.command()
+@click.argument("name")
+@click.option("--server-type", default="cx22", help="Hetzner server type (default: cx22).")
+@click.option("--image", default="ubuntu-24.04", help="OS image (default: ubuntu-24.04).")
+@click.option("--location", default="nbg1", help="Datacenter location (default: nbg1).")
+def create(name, server_type, image, location):
+    """Create a new Hetzner Cloud server.
+
+    NAME is the server name (e.g. my-app-production).
+    """
+    console = Console(file=sys.stdout)
+
+    # 1. Get Hetzner token
+    token = _get_or_prompt_hetzner_token()
+    client = HetznerClient(token)
+
+    # 2. Find and select SSH key
+    ssh_keys = _find_ssh_keys()
+    if not ssh_keys:
+        raise click.ClickException(
+            "No SSH public keys found in ~/.ssh/.\n"
+            "Generate one with: ssh-keygen -t ed25519\n"
+            "Then run this command again."
+        )
+
+    key_path, key_content = _select_ssh_key(ssh_keys)
+    key_name = key_path.stem  # e.g. "id_ed25519"
+
+    # 3. Ensure SSH key exists on Hetzner
+    with console.status("Uploading SSH key to Hetzner..."):
+        hetzner_key = client.ensure_ssh_key(key_name, key_content)
+
+    # 4. Create the server
+    with console.status(f"Creating server '{name}'..."):
+        response = client.create_server(
+            name=name,
+            ssh_key=hetzner_key,
+            server_type=server_type,
+            image=image,
+            location=location,
+        )
+
+    server_obj = response.server
+    ip = server_obj.public_net.ipv4.ip
+
+    # 5. Print results
+    console.print(f"\n[bold green]Server created successfully![/bold green]\n")
+    console.print(f"  Name:    {name}")
+    console.print(f"  Type:    {server_type}")
+    console.print(f"  Image:   {image}")
+    console.print(f"  IP:      {ip}")
+    console.print(f"\n  SSH:     [bold]ssh root@{ip}[/bold]\n")
+
+    # 6. Update Kamal config if present
+    if _update_kamal_config(ip):
+        console.print(
+            f"[bold]Updated {KAMAL_CONFIG_PATH} with server IP {ip}[/bold]"
+        )
+    else:
+        if not KAMAL_CONFIG_PATH.exists():
+            console.print(
+                "Tip: For Kamal deployment setup, see "
+                "https://docs.saaspegasus.com/deployment/kamal/"
+            )
+```
+
+**Step 4: Register the command in cli.py**
+
+In `pegasus_cli/cli.py`, add the import and registration:
+
+```python
+import click
+
+from .projects import auth, projects
+from .server import server
+from .startapp import startapp
+
+
+@click.group()
+@click.version_option(package_name="pegasus-cli")
+def cli():
+    """Usage"""
+
+
+cli.add_command(startapp)
+cli.add_command(auth)
+cli.add_command(projects)
+cli.add_command(server)
+```
+
+**Step 5: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_server.py -v`
+Expected: All pass.
+
+**Step 6: Run the full test suite**
+
+Run: `uv run pytest -v`
+Expected: All tests pass.
+
+**Step 7: Commit**
+
+```bash
+git add pegasus_cli/server.py pegasus_cli/cli.py tests/test_server.py
+git commit -m "Add 'pegasus server create' command for Hetzner provisioning"
+```
+
+---
+
+### Task 5: Manual smoke test
+
+This task cannot be automated but should be done before considering the feature complete.
+
+**Step 1: Verify CLI help**
+
+Run: `uv run pegasus server --help`
+Expected: Shows "Manage cloud servers." and lists `create` subcommand.
+
+Run: `uv run pegasus server create --help`
+Expected: Shows name argument, --server-type, --image, --location flags with defaults.
+
+**Step 2: Test auth flow (without a real token)**
+
+Run: `uv run pegasus server create test-server`
+Expected: Prompts for Hetzner API token with instructions.
+
+**Step 3: (Optional) Test with a real Hetzner token**
+
+If you have a Hetzner account, run the full flow and verify a server is created.
+Remember to destroy the server afterwards to avoid charges.

--- a/pegasus_cli/cli.py
+++ b/pegasus_cli/cli.py
@@ -1,6 +1,7 @@
 import click
 
 from .projects import auth, projects
+from .server import server
 from .startapp import startapp
 
 
@@ -13,3 +14,4 @@ def cli():
 cli.add_command(startapp)
 cli.add_command(auth)
 cli.add_command(projects)
+cli.add_command(server)

--- a/pegasus_cli/credentials.py
+++ b/pegasus_cli/credentials.py
@@ -26,6 +26,28 @@ def save_api_key(api_key: str) -> Path:
     return CREDENTIALS_FILE
 
 
+HETZNER_CREDENTIALS_FILE = CREDENTIALS_DIR / "hetzner_credentials"
+HETZNER_ENV_VAR = "HETZNER_API_TOKEN"
+
+
+def get_hetzner_api_key() -> str | None:
+    """Get the Hetzner API token, checking env var first, then credentials file."""
+    api_key = os.environ.get(HETZNER_ENV_VAR)
+    if api_key:
+        return api_key.strip()
+    if HETZNER_CREDENTIALS_FILE.exists():
+        return HETZNER_CREDENTIALS_FILE.read_text().strip()
+    return None
+
+
+def save_hetzner_api_key(api_key: str) -> Path:
+    """Save Hetzner API token to ~/.pegasus/hetzner_credentials. Returns the file path."""
+    CREDENTIALS_DIR.mkdir(parents=True, exist_ok=True)
+    HETZNER_CREDENTIALS_FILE.write_text(api_key.strip() + "\n")
+    HETZNER_CREDENTIALS_FILE.chmod(0o600)
+    return HETZNER_CREDENTIALS_FILE
+
+
 def get_base_url(cli_value: str | None = None) -> str:
     """Get the base URL. Priority: CLI flag > env var > default."""
     if cli_value:

--- a/pegasus_cli/hetzner_client.py
+++ b/pegasus_cli/hetzner_client.py
@@ -1,0 +1,43 @@
+import hcloud
+from hcloud.images import Image
+from hcloud.locations import Location
+from hcloud.server_types import ServerType
+from hcloud.ssh_keys import SSHKey
+
+
+class HetznerClient:
+    def __init__(self, token: str):
+        self.client = hcloud.Client(token=token)
+
+    def validate_token(self) -> None:
+        """Validate the token by making an API call. Raises on failure."""
+        self.client.servers.get_all()
+
+    def ensure_ssh_key(self, name: str, public_key: str) -> SSHKey:
+        """Find an existing SSH key by content, or upload it.
+
+        Matches by public key content (not name) to avoid duplicates.
+        """
+        existing_keys = self.client.ssh_keys.get_all()
+        for key in existing_keys:
+            if key.public_key.strip() == public_key.strip():
+                return key
+
+        return self.client.ssh_keys.create(name=name, public_key=public_key)
+
+    def create_server(
+        self,
+        name: str,
+        ssh_key: SSHKey,
+        server_type: str = "cx22",
+        image: str = "ubuntu-24.04",
+        location: str = "nbg1",
+    ):
+        """Create a Hetzner server. Returns the create response (has .server and .action)."""
+        return self.client.servers.create(
+            name=name,
+            server_type=ServerType(name=server_type),
+            image=Image(name=image),
+            location=Location(name=location),
+            ssh_keys=[ssh_key],
+        )

--- a/pegasus_cli/server.py
+++ b/pegasus_cli/server.py
@@ -1,0 +1,214 @@
+import sys
+from pathlib import Path
+
+import click
+import yaml
+from rich.console import Console
+
+from .credentials import get_hetzner_api_key, save_hetzner_api_key
+from .hetzner_client import HetznerClient
+
+KAMAL_CONFIG_PATH = Path("config/deploy.yml")
+
+
+def _find_ssh_keys() -> list[tuple[Path, str]]:
+    """Find SSH public keys in ~/.ssh/. Returns list of (path, content) tuples."""
+    ssh_dir = Path.home() / ".ssh"
+    if not ssh_dir.exists():
+        return []
+    keys = []
+    for pub_file in sorted(ssh_dir.glob("*.pub")):
+        try:
+            content = pub_file.read_text().strip()
+            if content:
+                keys.append((pub_file, content))
+        except OSError:
+            continue
+    return keys
+
+
+def _get_or_prompt_hetzner_token() -> str:
+    """Get Hetzner token from env/file, or prompt the user."""
+    token = get_hetzner_api_key()
+    if token:
+        return token
+
+    console = Console(file=sys.stdout)
+    console.print(
+        "\n[bold]No Hetzner API token found.[/bold]\n"
+        "\nTo create one:\n"
+        "  1. Go to https://console.hetzner.cloud\n"
+        "  2. Select your project\n"
+        "  3. Go to Security → API Tokens\n"
+        "  4. Generate a new token with Read & Write permissions\n"
+    )
+    token = click.prompt("Enter your Hetzner API token", hide_input=True)
+    if not token.strip():
+        raise click.ClickException("API token cannot be empty.")
+
+    # Validate the token
+    client = HetznerClient(token.strip())
+    try:
+        with console.status("Verifying token..."):
+            client.validate_token()
+    except Exception:
+        raise click.ClickException(
+            "Token validation failed. Please check your token and try again."
+        )
+
+    path = save_hetzner_api_key(token)
+    click.echo(f"Token saved to {path}")
+    return token.strip()
+
+
+def _select_ssh_key(keys: list[tuple[Path, str]]) -> tuple[Path, str]:
+    """Select an SSH key from the list. Prompts if multiple."""
+    if len(keys) == 1:
+        click.echo(f"Using SSH key: {keys[0][0].name}")
+        return keys[0]
+
+    click.echo("Multiple SSH keys found:")
+    for i, (path, _) in enumerate(keys, 1):
+        click.echo(f"  {i}. {path.name}")
+
+    choice = click.prompt(
+        "Select a key",
+        type=click.IntRange(1, len(keys)),
+    )
+    return keys[choice - 1]
+
+
+def _update_kamal_config(ip_address: str) -> bool:
+    """Update config/deploy.yml with the server IP if it exists.
+
+    Handles both simple list format and placeholder format:
+      servers:
+        - <IP-ADDRESS>
+      servers:
+        - 0.0.0.0
+
+    Returns True if config was updated, False otherwise.
+    """
+    if not KAMAL_CONFIG_PATH.exists():
+        return False
+
+    try:
+        content = KAMAL_CONFIG_PATH.read_text()
+        data = yaml.safe_load(content)
+    except Exception:
+        return False
+
+    if not isinstance(data, dict) or "servers" not in data:
+        return False
+
+    servers = data["servers"]
+
+    # Simple list format: servers: [ip1, ip2]
+    if isinstance(servers, list):
+        updated = False
+        for i, server in enumerate(servers):
+            if isinstance(server, str) and _is_placeholder_ip(server):
+                servers[i] = ip_address
+                updated = True
+        if updated:
+            with open(KAMAL_CONFIG_PATH, "w") as f:
+                yaml.dump(data, f, default_flow_style=False)
+            return True
+
+    # Role-based format: servers: {web: [ip1, ip2]}
+    if isinstance(servers, dict):
+        updated = False
+        for role, hosts in servers.items():
+            if isinstance(hosts, list):
+                for i, host in enumerate(hosts):
+                    if isinstance(host, str) and _is_placeholder_ip(host):
+                        hosts[i] = ip_address
+                        updated = True
+        if updated:
+            with open(KAMAL_CONFIG_PATH, "w") as f:
+                yaml.dump(data, f, default_flow_style=False)
+            return True
+
+    return False
+
+
+def _is_placeholder_ip(value: str) -> bool:
+    """Check if a server value looks like a placeholder."""
+    placeholders = {"<IP-ADDRESS>", "<ip-address>", "0.0.0.0", "<YOUR-IP>", "<your-ip>"}
+    return value.strip() in placeholders
+
+
+# --- CLI commands ---
+
+
+@click.group()
+def server():
+    """Manage cloud servers."""
+
+
+@server.command()
+@click.argument("name")
+@click.option(
+    "--server-type", default="cx22", help="Hetzner server type (default: cx22)."
+)
+@click.option(
+    "--image", default="ubuntu-24.04", help="OS image (default: ubuntu-24.04)."
+)
+@click.option("--location", default="nbg1", help="Datacenter location (default: nbg1).")
+def create(name, server_type, image, location):
+    """Create a new Hetzner Cloud server.
+
+    NAME is the server name (e.g. my-app-production).
+    """
+    console = Console(file=sys.stdout)
+
+    # 1. Get Hetzner token
+    token = _get_or_prompt_hetzner_token()
+    client = HetznerClient(token)
+
+    # 2. Find and select SSH key
+    ssh_keys = _find_ssh_keys()
+    if not ssh_keys:
+        raise click.ClickException(
+            "No SSH public keys found in ~/.ssh/.\n"
+            "Generate one with: ssh-keygen -t ed25519\n"
+            "Then run this command again."
+        )
+
+    key_path, key_content = _select_ssh_key(ssh_keys)
+    key_name = key_path.stem  # e.g. "id_ed25519"
+
+    # 3. Ensure SSH key exists on Hetzner
+    with console.status("Uploading SSH key to Hetzner..."):
+        hetzner_key = client.ensure_ssh_key(key_name, key_content)
+
+    # 4. Create the server
+    with console.status(f"Creating server '{name}'..."):
+        response = client.create_server(
+            name=name,
+            ssh_key=hetzner_key,
+            server_type=server_type,
+            image=image,
+            location=location,
+        )
+
+    server_obj = response.server
+    ip = server_obj.public_net.ipv4.ip
+
+    # 5. Print results
+    console.print("\n[bold green]Server created successfully![/bold green]\n")
+    console.print(f"  Name:    {name}")
+    console.print(f"  Type:    {server_type}")
+    console.print(f"  Image:   {image}")
+    console.print(f"  IP:      {ip}")
+    console.print(f"\n  SSH:     [bold]ssh root@{ip}[/bold]\n")
+
+    # 6. Update Kamal config if present
+    if _update_kamal_config(ip):
+        console.print(f"[bold]Updated {KAMAL_CONFIG_PATH} with server IP {ip}[/bold]")
+    else:
+        if not KAMAL_CONFIG_PATH.exists():
+            console.print(
+                "Tip: For Kamal deployment setup, see "
+                "https://docs.saaspegasus.com/deployment/kamal/"
+            )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,13 +9,15 @@ description = "CLI for Django and SaaS Pegasus"
 readme = "README.md"
 authors = [{name = "czue"}, {name = "snopoke"}]
 license = {text = "Apache-2.0"}
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 classifiers = [
     "License :: OSI Approved :: Apache Software License"
 ]
 dependencies = [
     "click",
     "cookiecutter",
+    "hcloud",
+    "pyyaml",
     "requests",
     "rich",
 ]

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -1,4 +1,10 @@
-from pegasus_cli.credentials import get_api_key, get_base_url, save_api_key
+from pegasus_cli.credentials import (
+    get_api_key,
+    get_base_url,
+    get_hetzner_api_key,
+    save_api_key,
+    save_hetzner_api_key,
+)
 
 
 def test_save_and_read_api_key(tmp_path, monkeypatch):
@@ -39,3 +45,28 @@ def test_get_base_url_cli_overrides_env(monkeypatch):
 def test_get_base_url_env(monkeypatch):
     monkeypatch.setenv("PEGASUS_BASE_URL", "https://env.example.com/")
     assert get_base_url() == "https://env.example.com"
+
+
+def test_save_and_read_hetzner_api_key(tmp_path, monkeypatch):
+    creds_dir = tmp_path / ".pegasus"
+    creds_file = creds_dir / "hetzner_credentials"
+    monkeypatch.setattr("pegasus_cli.credentials.CREDENTIALS_DIR", creds_dir)
+    monkeypatch.setattr("pegasus_cli.credentials.HETZNER_CREDENTIALS_FILE", creds_file)
+    monkeypatch.delenv("HETZNER_API_TOKEN", raising=False)
+
+    assert get_hetzner_api_key() is None
+
+    save_hetzner_api_key("hetzner-test-key")
+    assert get_hetzner_api_key() == "hetzner-test-key"
+    assert oct(creds_file.stat().st_mode)[-3:] == "600"
+
+
+def test_hetzner_env_var_takes_precedence(tmp_path, monkeypatch):
+    creds_dir = tmp_path / ".pegasus"
+    creds_file = creds_dir / "hetzner_credentials"
+    monkeypatch.setattr("pegasus_cli.credentials.CREDENTIALS_DIR", creds_dir)
+    monkeypatch.setattr("pegasus_cli.credentials.HETZNER_CREDENTIALS_FILE", creds_file)
+
+    save_hetzner_api_key("file-key")
+    monkeypatch.setenv("HETZNER_API_TOKEN", "env-key")
+    assert get_hetzner_api_key() == "env-key"

--- a/tests/test_hetzner_client.py
+++ b/tests/test_hetzner_client.py
@@ -1,0 +1,78 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from pegasus_cli.hetzner_client import HetznerClient
+
+
+@pytest.fixture
+def mock_hcloud():
+    """Patch hcloud.Client and return the mock instance."""
+    with patch("pegasus_cli.hetzner_client.hcloud.Client") as mock_cls:
+        client = HetznerClient("test-token")
+        yield client, mock_cls.return_value
+
+
+class TestValidateToken:
+    def test_validate_success(self, mock_hcloud):
+        client, mock_api = mock_hcloud
+        mock_api.servers.get_all.return_value = []
+        # Should not raise
+        client.validate_token()
+
+    def test_validate_failure(self, mock_hcloud):
+        client, mock_api = mock_hcloud
+        mock_api.servers.get_all.side_effect = Exception("Unauthorized")
+        with pytest.raises(Exception):
+            client.validate_token()
+
+
+class TestEnsureSshKey:
+    def test_key_already_exists(self, mock_hcloud):
+        client, mock_api = mock_hcloud
+        existing_key = MagicMock()
+        existing_key.name = "my-key"
+        existing_key.public_key = "ssh-ed25519 AAAA testkey"
+        mock_api.ssh_keys.get_all.return_value = [existing_key]
+
+        result = client.ensure_ssh_key("my-key", "ssh-ed25519 AAAA testkey")
+        assert result.name == "my-key"
+        mock_api.ssh_keys.create.assert_not_called()
+
+    def test_key_uploaded_when_missing(self, mock_hcloud):
+        client, mock_api = mock_hcloud
+        mock_api.ssh_keys.get_all.return_value = []
+        new_key = MagicMock()
+        new_key.name = "my-key"
+        mock_api.ssh_keys.create.return_value = new_key
+
+        result = client.ensure_ssh_key("my-key", "ssh-ed25519 AAAA testkey")
+        assert result.name == "my-key"
+        mock_api.ssh_keys.create.assert_called_once_with(
+            name="my-key", public_key="ssh-ed25519 AAAA testkey"
+        )
+
+
+class TestCreateServer:
+    def test_create_server(self, mock_hcloud):
+        client, mock_api = mock_hcloud
+        mock_server = MagicMock()
+        mock_server.public_net.ipv4.ip = "1.2.3.4"
+        mock_server.name = "my-server"
+        mock_server.server_type.name = "cx22"
+
+        mock_response = MagicMock()
+        mock_response.server = mock_server
+        mock_response.action = MagicMock()
+        mock_api.servers.create.return_value = mock_response
+
+        ssh_key = MagicMock()
+        result = client.create_server(
+            name="my-server",
+            ssh_key=ssh_key,
+            server_type="cx22",
+            image="ubuntu-24.04",
+            location="nbg1",
+        )
+        assert result.server.public_net.ipv4.ip == "1.2.3.4"
+        mock_api.servers.create.assert_called_once()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,163 @@
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from pegasus_cli.cli import cli
+
+
+def _mock_hetzner_client():
+    """Create a mock HetznerClient."""
+    client = MagicMock()
+    mock_server = MagicMock()
+    mock_server.public_net.ipv4.ip = "1.2.3.4"
+    mock_server.name = "my-server"
+    mock_server.server_type.name = "cx22"
+
+    mock_response = MagicMock()
+    mock_response.server = mock_server
+    mock_response.action = MagicMock()
+    client.create_server.return_value = mock_response
+
+    ssh_key = MagicMock()
+    ssh_key.name = "id_ed25519"
+    client.ensure_ssh_key.return_value = ssh_key
+
+    return client
+
+
+class TestServerCreate:
+    @patch("pegasus_cli.server.HetznerClient")
+    @patch("pegasus_cli.server.get_hetzner_api_key", return_value="test-token")
+    @patch("pegasus_cli.server._find_ssh_keys")
+    def test_create_basic(self, mock_find_keys, mock_get_key, mock_client_cls):
+        mock_find_keys.return_value = [
+            (Path("~/.ssh/id_ed25519.pub"), "ssh-ed25519 AAAA testkey")
+        ]
+        mock_client_cls.return_value = _mock_hetzner_client()
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["server", "create", "my-server"])
+        assert result.exit_code == 0
+        assert "1.2.3.4" in result.output
+        assert "ssh root@1.2.3.4" in result.output
+
+    @patch("pegasus_cli.server.HetznerClient")
+    @patch("pegasus_cli.server.get_hetzner_api_key", return_value="test-token")
+    @patch("pegasus_cli.server._find_ssh_keys")
+    def test_create_with_flags(self, mock_find_keys, mock_get_key, mock_client_cls):
+        mock_find_keys.return_value = [
+            (Path("~/.ssh/id_ed25519.pub"), "ssh-ed25519 AAAA testkey")
+        ]
+        client = _mock_hetzner_client()
+        mock_client_cls.return_value = client
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "server",
+                "create",
+                "my-server",
+                "--server-type",
+                "cx32",
+                "--image",
+                "ubuntu-22.04",
+                "--location",
+                "fsn1",
+            ],
+        )
+        assert result.exit_code == 0
+        client.create_server.assert_called_once_with(
+            name="my-server",
+            ssh_key=client.ensure_ssh_key.return_value,
+            server_type="cx32",
+            image="ubuntu-22.04",
+            location="fsn1",
+        )
+
+    @patch("pegasus_cli.server._find_ssh_keys")
+    def test_create_no_api_key_prompts(self, mock_find_keys):
+        """When no Hetzner token is found, prompt the user."""
+        mock_find_keys.return_value = [
+            (Path("~/.ssh/id_ed25519.pub"), "ssh-ed25519 AAAA testkey")
+        ]
+        runner = CliRunner()
+        with patch("pegasus_cli.server.get_hetzner_api_key", return_value=None):
+            with patch("pegasus_cli.server.HetznerClient") as mock_cls:
+                mock_cls.return_value = _mock_hetzner_client()
+                with patch("pegasus_cli.server.save_hetzner_api_key") as mock_save:
+                    mock_save.return_value = Path("~/.pegasus/hetzner_credentials")
+                    result = runner.invoke(
+                        cli,
+                        ["server", "create", "my-server"],
+                        input="my-hetzner-token\n",
+                    )
+                    assert result.exit_code == 0
+                    mock_save.assert_called_once_with("my-hetzner-token")
+
+    @patch("pegasus_cli.server.get_hetzner_api_key", return_value="test-token")
+    @patch("pegasus_cli.server._find_ssh_keys")
+    def test_create_no_ssh_keys(self, mock_find_keys, mock_get_key):
+        mock_find_keys.return_value = []
+        runner = CliRunner()
+        result = runner.invoke(cli, ["server", "create", "my-server"])
+        assert result.exit_code != 0
+        assert "ssh-keygen" in result.output
+
+    @patch("pegasus_cli.server.HetznerClient")
+    @patch("pegasus_cli.server.get_hetzner_api_key", return_value="test-token")
+    @patch("pegasus_cli.server._find_ssh_keys")
+    def test_create_multiple_ssh_keys_prompts(
+        self, mock_find_keys, mock_get_key, mock_client_cls
+    ):
+        mock_find_keys.return_value = [
+            (Path("~/.ssh/id_ed25519.pub"), "ssh-ed25519 AAAA key1"),
+            (Path("~/.ssh/id_rsa.pub"), "ssh-rsa BBBB key2"),
+        ]
+        mock_client_cls.return_value = _mock_hetzner_client()
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["server", "create", "my-server"], input="1\n")
+        assert result.exit_code == 0
+        assert "1.2.3.4" in result.output
+
+    @patch("pegasus_cli.server.HetznerClient")
+    @patch("pegasus_cli.server.get_hetzner_api_key", return_value="test-token")
+    @patch("pegasus_cli.server._find_ssh_keys")
+    def test_create_updates_kamal_config(
+        self, mock_find_keys, mock_get_key, mock_client_cls
+    ):
+        mock_find_keys.return_value = [
+            (Path("~/.ssh/id_ed25519.pub"), "ssh-ed25519 AAAA testkey")
+        ]
+        mock_client_cls.return_value = _mock_hetzner_client()
+
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            # Create a Kamal deploy config
+            Path("config").mkdir()
+            Path("config/deploy.yml").write_text("servers:\n  - <IP-ADDRESS>\n")
+            result = runner.invoke(cli, ["server", "create", "my-server"])
+            assert result.exit_code == 0
+            # Verify the config was updated
+            config = Path("config/deploy.yml").read_text()
+            assert "1.2.3.4" in config
+            assert "<IP-ADDRESS>" not in config
+
+    @patch("pegasus_cli.server.HetznerClient")
+    @patch("pegasus_cli.server.get_hetzner_api_key", return_value="test-token")
+    @patch("pegasus_cli.server._find_ssh_keys")
+    def test_create_no_kamal_config_shows_docs_link(
+        self, mock_find_keys, mock_get_key, mock_client_cls
+    ):
+        mock_find_keys.return_value = [
+            (Path("~/.ssh/id_ed25519.pub"), "ssh-ed25519 AAAA testkey")
+        ]
+        mock_client_cls.return_value = _mock_hetzner_client()
+
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            result = runner.invoke(cli, ["server", "create", "my-server"])
+            assert result.exit_code == 0
+            assert "docs.saaspegasus.com" in result.output

--- a/uv.lock
+++ b/uv.lock
@@ -1,10 +1,6 @@
 version = 1
 revision = 3
-requires-python = ">=3.9"
-resolution-markers = [
-    "python_full_version >= '3.10'",
-    "python_full_version < '3.10'",
-]
+requires-python = ">=3.10"
 
 [[package]]
 name = "arrow"
@@ -42,23 +38,8 @@ wheels = [
 
 [[package]]
 name = "cfgv"
-version = "3.4.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.10'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/11/74/539e56497d9bd1d484fd863dd69cbbfa653cd2aa27abfe35653494d85e94/cfgv-3.4.0.tar.gz", hash = "sha256:e52591d4c5f5dead8e0f673fb16db7949d2cfb3f7da4582893288f0ded8fe560", size = 7114, upload-time = "2023-08-12T20:38:17.776Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c5/55/51844dd50c4fc7a33b653bfaba4c2456f06955289ca770a5dbd5fd267374/cfgv-3.4.0-py2.py3-none-any.whl", hash = "sha256:b7265b1f29fd3316bfcd2b330d63d024f2bfd8bcb8b0272f8e19a504856c48f9", size = 7249, upload-time = "2023-08-12T20:38:16.269Z" },
-]
-
-[[package]]
-name = "cfgv"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.10'",
-]
 sdist = { url = "https://files.pythonhosted.org/packages/4e/b5/721b8799b04bf9afe054a3899c6cf4e880fcf8563cc71c15610242490a0c/cfgv-3.5.0.tar.gz", hash = "sha256:d5b1034354820651caa73ede66a6294d6e95c1b00acc5e9b098e917404669132", size = 7334, upload-time = "2025-11-19T20:55:51.612Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl", hash = "sha256:a8dc6b26ad22ff227d2634a65cb388215ce6cc96bbcc5cfde7641ae87e8dacc0", size = 7445, upload-time = "2025-11-19T20:55:50.744Z" },
@@ -159,49 +140,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b0/6f/8f7af07237c34a1defe7defc565a9bc1807762f672c0fde711a4b22bf9c0/charset_normalizer-3.4.4-cp314-cp314-win32.whl", hash = "sha256:f9d332f8c2a2fcbffe1378594431458ddbef721c1769d78e2cbc06280d8155f9", size = 99940, upload-time = "2025-10-14T04:41:49.946Z" },
     { url = "https://files.pythonhosted.org/packages/4b/51/8ade005e5ca5b0d80fb4aff72a3775b325bdc3d27408c8113811a7cbe640/charset_normalizer-3.4.4-cp314-cp314-win_amd64.whl", hash = "sha256:8a6562c3700cce886c5be75ade4a5db4214fda19fede41d9792d100288d8f94c", size = 107104, upload-time = "2025-10-14T04:41:51.051Z" },
     { url = "https://files.pythonhosted.org/packages/da/5f/6b8f83a55bb8278772c5ae54a577f3099025f9ade59d0136ac24a0df4bde/charset_normalizer-3.4.4-cp314-cp314-win_arm64.whl", hash = "sha256:de00632ca48df9daf77a2c65a484531649261ec9f25489917f09e455cb09ddb2", size = 100743, upload-time = "2025-10-14T04:41:52.122Z" },
-    { url = "https://files.pythonhosted.org/packages/46/7c/0c4760bccf082737ca7ab84a4c2034fcc06b1f21cf3032ea98bd6feb1725/charset_normalizer-3.4.4-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:a9768c477b9d7bd54bc0c86dbaebdec6f03306675526c9927c0e8a04e8f94af9", size = 209609, upload-time = "2025-10-14T04:42:10.922Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/a4/69719daef2f3d7f1819de60c9a6be981b8eeead7542d5ec4440f3c80e111/charset_normalizer-3.4.4-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1bee1e43c28aa63cb16e5c14e582580546b08e535299b8b6158a7c9c768a1f3d", size = 149029, upload-time = "2025-10-14T04:42:12.38Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/21/8d4e1d6c1e6070d3672908b8e4533a71b5b53e71d16828cc24d0efec564c/charset_normalizer-3.4.4-cp39-cp39-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:fd44c878ea55ba351104cb93cc85e74916eb8fa440ca7903e57575e97394f608", size = 144580, upload-time = "2025-10-14T04:42:13.549Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/0a/a616d001b3f25647a9068e0b9199f697ce507ec898cacb06a0d5a1617c99/charset_normalizer-3.4.4-cp39-cp39-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:0f04b14ffe5fdc8c4933862d8306109a2c51e0704acfa35d51598eb45a1e89fc", size = 162340, upload-time = "2025-10-14T04:42:14.892Z" },
-    { url = "https://files.pythonhosted.org/packages/85/93/060b52deb249a5450460e0585c88a904a83aec474ab8e7aba787f45e79f2/charset_normalizer-3.4.4-cp39-cp39-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:cd09d08005f958f370f539f186d10aec3377d55b9eeb0d796025d4886119d76e", size = 159619, upload-time = "2025-10-14T04:42:16.676Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/21/0274deb1cc0632cd587a9a0ec6b4674d9108e461cb4cd40d457adaeb0564/charset_normalizer-3.4.4-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4fe7859a4e3e8457458e2ff592f15ccb02f3da787fcd31e0183879c3ad4692a1", size = 153980, upload-time = "2025-10-14T04:42:17.917Z" },
-    { url = "https://files.pythonhosted.org/packages/28/2b/e3d7d982858dccc11b31906976323d790dded2017a0572f093ff982d692f/charset_normalizer-3.4.4-cp39-cp39-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fa09f53c465e532f4d3db095e0c55b615f010ad81803d383195b6b5ca6cbf5f3", size = 152174, upload-time = "2025-10-14T04:42:19.018Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/ff/4a269f8e35f1e58b2df52c131a1fa019acb7ef3f8697b7d464b07e9b492d/charset_normalizer-3.4.4-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:7fa17817dc5625de8a027cb8b26d9fefa3ea28c8253929b8d6649e705d2835b6", size = 151666, upload-time = "2025-10-14T04:42:20.171Z" },
-    { url = "https://files.pythonhosted.org/packages/da/c9/ec39870f0b330d58486001dd8e532c6b9a905f5765f58a6f8204926b4a93/charset_normalizer-3.4.4-cp39-cp39-musllinux_1_2_armv7l.whl", hash = "sha256:5947809c8a2417be3267efc979c47d76a079758166f7d43ef5ae8e9f92751f88", size = 145550, upload-time = "2025-10-14T04:42:21.324Z" },
-    { url = "https://files.pythonhosted.org/packages/75/8f/d186ab99e40e0ed9f82f033d6e49001701c81244d01905dd4a6924191a30/charset_normalizer-3.4.4-cp39-cp39-musllinux_1_2_ppc64le.whl", hash = "sha256:4902828217069c3c5c71094537a8e623f5d097858ac6ca8252f7b4d10b7560f1", size = 163721, upload-time = "2025-10-14T04:42:22.46Z" },
-    { url = "https://files.pythonhosted.org/packages/96/b1/6047663b9744df26a7e479ac1e77af7134b1fcf9026243bb48ee2d18810f/charset_normalizer-3.4.4-cp39-cp39-musllinux_1_2_riscv64.whl", hash = "sha256:7c308f7e26e4363d79df40ca5b2be1c6ba9f02bdbccfed5abddb7859a6ce72cf", size = 152127, upload-time = "2025-10-14T04:42:23.712Z" },
-    { url = "https://files.pythonhosted.org/packages/59/78/e5a6eac9179f24f704d1be67d08704c3c6ab9f00963963524be27c18ed87/charset_normalizer-3.4.4-cp39-cp39-musllinux_1_2_s390x.whl", hash = "sha256:2c9d3c380143a1fedbff95a312aa798578371eb29da42106a29019368a475318", size = 161175, upload-time = "2025-10-14T04:42:24.87Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/43/0e626e42d54dd2f8dd6fc5e1c5ff00f05fbca17cb699bedead2cae69c62f/charset_normalizer-3.4.4-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:cb01158d8b88ee68f15949894ccc6712278243d95f344770fa7593fa2d94410c", size = 155375, upload-time = "2025-10-14T04:42:27.246Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/91/d9615bf2e06f35e4997616ff31248c3657ed649c5ab9d35ea12fce54e380/charset_normalizer-3.4.4-cp39-cp39-win32.whl", hash = "sha256:2677acec1a2f8ef614c6888b5b4ae4060cc184174a938ed4e8ef690e15d3e505", size = 99692, upload-time = "2025-10-14T04:42:28.425Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/a9/6c040053909d9d1ef4fcab45fddec083aedc9052c10078339b47c8573ea8/charset_normalizer-3.4.4-cp39-cp39-win_amd64.whl", hash = "sha256:f8e160feb2aed042cd657a72acc0b481212ed28b1b9a95c0cee1621b524e1966", size = 107192, upload-time = "2025-10-14T04:42:29.482Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/c6/4fa536b2c0cd3edfb7ccf8469fa0f363ea67b7213a842b90909ca33dd851/charset_normalizer-3.4.4-cp39-cp39-win_arm64.whl", hash = "sha256:b5d84d37db046c5ca74ee7bb47dd6cbc13f80665fdde3e8040bdd3fb015ecb50", size = 100220, upload-time = "2025-10-14T04:42:30.632Z" },
     { url = "https://files.pythonhosted.org/packages/0a/4c/925909008ed5a988ccbb72dcc897407e5d6d3bd72410d69e051fc0c14647/charset_normalizer-3.4.4-py3-none-any.whl", hash = "sha256:7a32c560861a02ff789ad905a2fe94e3f840803362c84fecf1851cb4cf3dc37f", size = 53402, upload-time = "2025-10-14T04:42:31.76Z" },
-]
-
-[[package]]
-name = "click"
-version = "8.1.8"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.10'",
-]
-dependencies = [
-    { name = "colorama", marker = "python_full_version < '3.10' and sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593, upload-time = "2024-12-21T18:38:44.339Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/d4/7ebdbd03970677812aac39c869717059dbb71a4cfc033ca6e5221787892c/click-8.1.8-py3-none-any.whl", hash = "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2", size = 98188, upload-time = "2024-12-21T18:38:41.666Z" },
 ]
 
 [[package]]
 name = "click"
 version = "8.3.1"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.10'",
-]
 dependencies = [
-    { name = "colorama", marker = "python_full_version >= '3.10' and sys_platform == 'win32'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
 wheels = [
@@ -224,8 +171,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "arrow" },
     { name = "binaryornot" },
-    { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "click", version = "8.3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "click" },
     { name = "jinja2" },
     { name = "python-slugify" },
     { name = "pyyaml" },
@@ -260,47 +206,30 @@ wheels = [
 
 [[package]]
 name = "filelock"
-version = "3.19.1"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.10'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/40/bb/0ab3e58d22305b6f5440629d20683af28959bf793d98d11950e305c1c326/filelock-3.19.1.tar.gz", hash = "sha256:66eda1888b0171c998b35be2bcc0f6d75c388a7ce20c3f3f37aa8e96c2dddf58", size = 17687, upload-time = "2025-08-14T16:56:03.016Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/42/14/42b2651a2f46b022ccd948bca9f2d5af0fd8929c4eec235b8d6d844fbe67/filelock-3.19.1-py3-none-any.whl", hash = "sha256:d38e30481def20772f5baf097c122c3babc4fcdb7e14e57049eb9d88c6dc017d", size = 15988, upload-time = "2025-08-14T16:56:01.633Z" },
-]
-
-[[package]]
-name = "filelock"
 version = "3.20.3"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.10'",
-]
 sdist = { url = "https://files.pythonhosted.org/packages/1d/65/ce7f1b70157833bf3cb851b556a37d4547ceafc158aa9b34b36782f23696/filelock-3.20.3.tar.gz", hash = "sha256:18c57ee915c7ec61cff0ecf7f0f869936c7c30191bb0cf406f1341778d0834e1", size = 19485, upload-time = "2026-01-09T17:55:05.421Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b5/36/7fb70f04bf00bc646cd5bb45aa9eddb15e19437a28b8fb2b4a5249fac770/filelock-3.20.3-py3-none-any.whl", hash = "sha256:4b0dda527ee31078689fc205ec4f1c1bf7d56cf88b6dc9426c4f230e46c2dce1", size = 16701, upload-time = "2026-01-09T17:55:04.334Z" },
 ]
 
 [[package]]
-name = "identify"
-version = "2.6.15"
+name = "hcloud"
+version = "2.16.0"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.10'",
+dependencies = [
+    { name = "python-dateutil" },
+    { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ff/e7/685de97986c916a6d93b3876139e00eef26ad5bbbd61925d670ae8013449/identify-2.6.15.tar.gz", hash = "sha256:e4f4864b96c6557ef2a1e1c951771838f4edc9df3a72ec7118b338801b11c7bf", size = 99311, upload-time = "2025-10-02T17:43:40.631Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c8/86/1b4aae77f953e9408e3feffa6beec111136cb423e95e965b8a268c292628/hcloud-2.16.0.tar.gz", hash = "sha256:eb1acb3115bc0b356b450ad23256873b58311b357a49625a8fe0cbaba2db509b", size = 153827, upload-time = "2026-01-23T12:14:13.015Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0f/1c/e5fd8f973d4f375adb21565739498e2e9a1e54c858a97b9a8ccfdc81da9b/identify-2.6.15-py2.py3-none-any.whl", hash = "sha256:1181ef7608e00704db228516541eb83a88a9f94433a8c80bb9b5bd54b1d81757", size = 99183, upload-time = "2025-10-02T17:43:39.137Z" },
+    { url = "https://files.pythonhosted.org/packages/47/9c/e4f662d6576bb0f36aac4b301b5600116ba3cfc68c27a5a2ce51996b7b03/hcloud-2.16.0-py3-none-any.whl", hash = "sha256:37b3ef30be1034299879d1da89b2ed34e907b79796b684e16d8d6f76bd4a3c47", size = 111392, upload-time = "2026-01-23T12:14:11.422Z" },
 ]
 
 [[package]]
 name = "identify"
 version = "2.6.16"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.10'",
-]
 sdist = { url = "https://files.pythonhosted.org/packages/5b/8d/e8b97e6bd3fb6fb271346f7981362f1e04d6a7463abd0de79e1fda17c067/identify-2.6.16.tar.gz", hash = "sha256:846857203b5511bbe94d5a352a48ef2359532bc8f6727b5544077a0dcfb24980", size = 99360, upload-time = "2026-01-12T18:58:58.201Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b8/58/40fbbcefeda82364720eba5cf2270f98496bdfa19ea75b4cccae79c698e6/identify-2.6.16-py2.py3-none-any.whl", hash = "sha256:391ee4d77741d994189522896270b787aed8670389bfd60f326d677d64a6dfb0", size = 99202, upload-time = "2026-01-12T18:58:56.627Z" },
@@ -317,23 +246,8 @@ wheels = [
 
 [[package]]
 name = "iniconfig"
-version = "2.1.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.10'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793, upload-time = "2025-03-19T20:09:59.721Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050, upload-time = "2025-03-19T20:10:01.071Z" },
-]
-
-[[package]]
-name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.10'",
-]
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
@@ -353,28 +267,10 @@ wheels = [
 
 [[package]]
 name = "markdown-it-py"
-version = "3.0.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.10'",
-]
-dependencies = [
-    { name = "mdurl", marker = "python_full_version < '3.10'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/38/71/3b932df36c1a044d397a1f92d1cf91ee0a503d91e470cbd670aa66b07ed0/markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb", size = 74596, upload-time = "2023-06-03T06:41:14.443Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/42/d7/1ec15b46af6af88f19b8e5ffea08fa375d433c998b8a7639e76935c14f1f/markdown_it_py-3.0.0-py3-none-any.whl", hash = "sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1", size = 87528, upload-time = "2023-06-03T06:41:11.019Z" },
-]
-
-[[package]]
-name = "markdown-it-py"
 version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.10'",
-]
 dependencies = [
-    { name = "mdurl", marker = "python_full_version >= '3.10'" },
+    { name = "mdurl" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
 wheels = [
@@ -464,17 +360,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
     { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
     { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
-    { url = "https://files.pythonhosted.org/packages/56/23/0d8c13a44bde9154821586520840643467aee574d8ce79a17da539ee7fed/markupsafe-3.0.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:15d939a21d546304880945ca1ecb8a039db6b4dc49b2c5a400387cdae6a62e26", size = 11623, upload-time = "2025-09-27T18:37:29.296Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/23/07a2cb9a8045d5f3f0890a8c3bc0859d7a47bfd9a560b563899bec7b72ed/markupsafe-3.0.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:f71a396b3bf33ecaa1626c255855702aca4d3d9fea5e051b41ac59a9c1c41edc", size = 12049, upload-time = "2025-09-27T18:37:30.234Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/e4/6be85eb81503f8e11b61c0b6369b6e077dcf0a74adbd9ebf6b349937b4e9/markupsafe-3.0.3-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0f4b68347f8c5eab4a13419215bdfd7f8c9b19f2b25520968adfad23eb0ce60c", size = 21923, upload-time = "2025-09-27T18:37:31.177Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/bc/4dc914ead3fe6ddaef035341fee0fc956949bbd27335b611829292b89ee2/markupsafe-3.0.3-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e8fc20152abba6b83724d7ff268c249fa196d8259ff481f3b1476383f8f24e42", size = 20543, upload-time = "2025-09-27T18:37:32.168Z" },
-    { url = "https://files.pythonhosted.org/packages/89/6e/5fe81fbcfba4aef4093d5f856e5c774ec2057946052d18d168219b7bd9f9/markupsafe-3.0.3-cp39-cp39-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:949b8d66bc381ee8b007cd945914c721d9aba8e27f71959d750a46f7c282b20b", size = 20585, upload-time = "2025-09-27T18:37:33.166Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/f6/e0e5a3d3ae9c4020f696cd055f940ef86b64fe88de26f3a0308b9d3d048c/markupsafe-3.0.3-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:3537e01efc9d4dccdf77221fb1cb3b8e1a38d5428920e0657ce299b20324d758", size = 21387, upload-time = "2025-09-27T18:37:34.185Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/25/651753ef4dea08ea790f4fbb65146a9a44a014986996ca40102e237aa49a/markupsafe-3.0.3-cp39-cp39-musllinux_1_2_riscv64.whl", hash = "sha256:591ae9f2a647529ca990bc681daebdd52c8791ff06c2bfa05b65163e28102ef2", size = 20133, upload-time = "2025-09-27T18:37:35.138Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/0a/c3cf2b4fef5f0426e8a6d7fce3cb966a17817c568ce59d76b92a233fdbec/markupsafe-3.0.3-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:a320721ab5a1aba0a233739394eb907f8c8da5c98c9181d1161e77a0c8e36f2d", size = 20588, upload-time = "2025-09-27T18:37:36.096Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/1b/a7782984844bd519ad4ffdbebbba2671ec5d0ebbeac34736c15fb86399e8/markupsafe-3.0.3-cp39-cp39-win32.whl", hash = "sha256:df2449253ef108a379b8b5d6b43f4b1a8e81a061d6537becd5582fba5f9196d7", size = 14566, upload-time = "2025-09-27T18:37:37.09Z" },
-    { url = "https://files.pythonhosted.org/packages/18/1f/8d9c20e1c9440e215a44be5ab64359e207fcb4f675543f1cf9a2a7f648d0/markupsafe-3.0.3-cp39-cp39-win_amd64.whl", hash = "sha256:7c3fb7d25180895632e5d3148dbdc29ea38ccb7fd210aa27acbd1201a1902c6e", size = 15053, upload-time = "2025-09-27T18:37:38.054Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/d3/fe08482b5cd995033556d45041a4f4e76e7f0521112a9c9991d40d39825f/markupsafe-3.0.3-cp39-cp39-win_arm64.whl", hash = "sha256:38664109c14ffc9e7437e86b4dceb442b0096dfe3541d7864d9cbe1da4cf36c8", size = 13928, upload-time = "2025-09-27T18:37:39.037Z" },
 ]
 
 [[package]]
@@ -509,19 +394,18 @@ name = "pegasus-cli"
 version = "0.12"
 source = { editable = "." }
 dependencies = [
-    { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "click", version = "8.3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "click" },
     { name = "cookiecutter" },
+    { name = "hcloud" },
+    { name = "pyyaml" },
     { name = "requests" },
     { name = "rich" },
 ]
 
 [package.dev-dependencies]
 dev = [
-    { name = "pre-commit", version = "4.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "pre-commit", version = "4.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "pytest", version = "9.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pre-commit" },
+    { name = "pytest" },
     { name = "ruff" },
 ]
 
@@ -529,6 +413,8 @@ dev = [
 requires-dist = [
     { name = "click" },
     { name = "cookiecutter" },
+    { name = "hcloud" },
+    { name = "pyyaml" },
     { name = "requests" },
     { name = "rich" },
 ]
@@ -542,23 +428,8 @@ dev = [
 
 [[package]]
 name = "platformdirs"
-version = "4.4.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.10'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/23/e8/21db9c9987b0e728855bd57bff6984f67952bea55d6f75e055c46b5383e8/platformdirs-4.4.0.tar.gz", hash = "sha256:ca753cf4d81dc309bc67b0ea38fd15dc97bc30ce419a7f58d13eb3bf14c4febf", size = 21634, upload-time = "2025-08-26T14:32:04.268Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/40/4b/2028861e724d3bd36227adfa20d3fd24c3fc6d52032f4a93c133be5d17ce/platformdirs-4.4.0-py3-none-any.whl", hash = "sha256:abd01743f24e5287cd7a5db3752faf1a2d65353f38ec26d98e25a6db65958c85", size = 18654, upload-time = "2025-08-26T14:32:02.735Z" },
-]
-
-[[package]]
-name = "platformdirs"
 version = "4.5.1"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.10'",
-]
 sdist = { url = "https://files.pythonhosted.org/packages/cf/86/0248f086a84f01b37aaec0fa567b397df1a119f73c16f6c7a9aac73ea309/platformdirs-4.5.1.tar.gz", hash = "sha256:61d5cdcc6065745cdd94f0f878977f8de9437be93de97c1c12f853c9c0cdcbda", size = 21715, upload-time = "2025-12-05T13:52:58.638Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/28/3bfe2fa5a7b9c46fe7e13c97bda14c895fb10fa2ebf1d0abb90e0cea7ee1/platformdirs-4.5.1-py3-none-any.whl", hash = "sha256:d03afa3963c806a9bed9d5125c8f4cb2fdaf74a55ab60e5d59b3fde758104d31", size = 18731, upload-time = "2025-12-05T13:52:56.823Z" },
@@ -575,36 +446,14 @@ wheels = [
 
 [[package]]
 name = "pre-commit"
-version = "4.3.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.10'",
-]
-dependencies = [
-    { name = "cfgv", version = "3.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "identify", version = "2.6.15", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "nodeenv", marker = "python_full_version < '3.10'" },
-    { name = "pyyaml", marker = "python_full_version < '3.10'" },
-    { name = "virtualenv", marker = "python_full_version < '3.10'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ff/29/7cf5bbc236333876e4b41f56e06857a87937ce4bf91e117a6991a2dbb02a/pre_commit-4.3.0.tar.gz", hash = "sha256:499fe450cc9d42e9d58e606262795ecb64dd05438943c62b66f6a8673da30b16", size = 193792, upload-time = "2025-08-09T18:56:14.651Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5b/a5/987a405322d78a73b66e39e4a90e4ef156fd7141bf71df987e50717c321b/pre_commit-4.3.0-py2.py3-none-any.whl", hash = "sha256:2b0747ad7e6e967169136edffee14c16e148a778a54e4f967921aa1ebf2308d8", size = 220965, upload-time = "2025-08-09T18:56:13.192Z" },
-]
-
-[[package]]
-name = "pre-commit"
 version = "4.5.1"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.10'",
-]
 dependencies = [
-    { name = "cfgv", version = "3.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "identify", version = "2.6.16", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "nodeenv", marker = "python_full_version >= '3.10'" },
-    { name = "pyyaml", marker = "python_full_version >= '3.10'" },
-    { name = "virtualenv", marker = "python_full_version >= '3.10'" },
+    { name = "cfgv" },
+    { name = "identify" },
+    { name = "nodeenv" },
+    { name = "pyyaml" },
+    { name = "virtualenv" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/40/f1/6d86a29246dfd2e9b6237f0b5823717f60cad94d47ddc26afa916d21f525/pre_commit-4.5.1.tar.gz", hash = "sha256:eb545fcff725875197837263e977ea257a402056661f09dae08e4b149b030a61", size = 198232, upload-time = "2025-12-16T21:14:33.552Z" }
 wheels = [
@@ -622,40 +471,16 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.10'",
-]
-dependencies = [
-    { name = "colorama", marker = "python_full_version < '3.10' and sys_platform == 'win32'" },
-    { name = "exceptiongroup", marker = "python_full_version < '3.10'" },
-    { name = "iniconfig", version = "2.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "packaging", marker = "python_full_version < '3.10'" },
-    { name = "pluggy", marker = "python_full_version < '3.10'" },
-    { name = "pygments", marker = "python_full_version < '3.10'" },
-    { name = "tomli", marker = "python_full_version < '3.10'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79", size = 365750, upload-time = "2025-09-04T14:34:20.226Z" },
-]
-
-[[package]]
-name = "pytest"
 version = "9.0.2"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.10'",
-]
 dependencies = [
-    { name = "colorama", marker = "python_full_version >= '3.10' and sys_platform == 'win32'" },
-    { name = "exceptiongroup", marker = "python_full_version == '3.10.*'" },
-    { name = "iniconfig", version = "2.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "packaging", marker = "python_full_version >= '3.10'" },
-    { name = "pluggy", marker = "python_full_version >= '3.10'" },
-    { name = "pygments", marker = "python_full_version >= '3.10'" },
-    { name = "tomli", marker = "python_full_version == '3.10.*'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
 wheels = [
@@ -748,15 +573,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/62/67fc8e68a75f738c9200422bf65693fb79a4cd0dc5b23310e5202e978090/pyyaml-6.0.3-cp39-cp39-macosx_10_13_x86_64.whl", hash = "sha256:b865addae83924361678b652338317d1bd7e79b1f4596f96b96c77a5a34b34da", size = 184450, upload-time = "2025-09-25T21:33:00.618Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/92/861f152ce87c452b11b9d0977952259aa7df792d71c1053365cc7b09cc08/pyyaml-6.0.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:c3355370a2c156cffb25e876646f149d5d68f5e0a3ce86a5084dd0b64a994917", size = 174319, upload-time = "2025-09-25T21:33:02.086Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/cd/f0cfc8c74f8a030017a2b9c771b7f47e5dd702c3e28e5b2071374bda2948/pyyaml-6.0.3-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3c5677e12444c15717b902a5798264fa7909e41153cdf9ef7ad571b704a63dd9", size = 737631, upload-time = "2025-09-25T21:33:03.25Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/b2/18f2bd28cd2055a79a46c9b0895c0b3d987ce40ee471cecf58a1a0199805/pyyaml-6.0.3-cp39-cp39-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5ed875a24292240029e4483f9d4a4b8a1ae08843b9c54f43fcc11e404532a8a5", size = 836795, upload-time = "2025-09-25T21:33:05.014Z" },
-    { url = "https://files.pythonhosted.org/packages/73/b9/793686b2d54b531203c160ef12bec60228a0109c79bae6c1277961026770/pyyaml-6.0.3-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0150219816b6a1fa26fb4699fb7daa9caf09eb1999f3b70fb6e786805e80375a", size = 750767, upload-time = "2025-09-25T21:33:06.398Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/86/a137b39a611def2ed78b0e66ce2fe13ee701a07c07aebe55c340ed2a050e/pyyaml-6.0.3-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:fa160448684b4e94d80416c0fa4aac48967a969efe22931448d853ada8baf926", size = 727982, upload-time = "2025-09-25T21:33:08.708Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/62/71c27c94f457cf4418ef8ccc71735324c549f7e3ea9d34aba50874563561/pyyaml-6.0.3-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:27c0abcb4a5dac13684a37f76e701e054692a9b2d3064b70f5e4eb54810553d7", size = 755677, upload-time = "2025-09-25T21:33:09.876Z" },
-    { url = "https://files.pythonhosted.org/packages/29/3d/6f5e0d58bd924fb0d06c3a6bad00effbdae2de5adb5cda5648006ffbd8d3/pyyaml-6.0.3-cp39-cp39-win32.whl", hash = "sha256:1ebe39cb5fc479422b83de611d14e2c0d3bb2a18bbcb01f229ab3cfbd8fee7a0", size = 142592, upload-time = "2025-09-25T21:33:10.983Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/0c/25113e0b5e103d7f1490c0e947e303fe4a696c10b501dea7a9f49d4e876c/pyyaml-6.0.3-cp39-cp39-win_amd64.whl", hash = "sha256:2e71d11abed7344e42a8849600193d15b6def118602c4c176f748e4583246007", size = 158777, upload-time = "2025-09-25T21:33:15.55Z" },
 ]
 
 [[package]]
@@ -779,8 +595,7 @@ name = "rich"
 version = "14.3.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "markdown-it-py", version = "3.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "markdown-it-py", version = "4.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "markdown-it-py" },
     { name = "pygments" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/74/99/a4cab2acbb884f80e558b0771e97e21e939c5dfb460f488d19df485e8298/rich-14.3.2.tar.gz", hash = "sha256:e712f11c1a562a11843306f5ed999475f09ac31ffb64281f73ab29ffdda8b3b8", size = 230143, upload-time = "2026-02-01T16:20:47.908Z" }
@@ -918,10 +733,8 @@ version = "20.36.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "distlib" },
-    { name = "filelock", version = "3.19.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "filelock", version = "3.20.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "platformdirs", version = "4.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "platformdirs", version = "4.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "filelock" },
+    { name = "platformdirs" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/aa/a3/4d310fa5f00863544e1d0f4de93bddec248499ccf97d4791bc3122c9d4f3/virtualenv-20.36.1.tar.gz", hash = "sha256:8befb5c81842c641f8ee658481e42641c68b5eab3521d8e092d18320902466ba", size = 6032239, upload-time = "2026-01-09T18:21:01.296Z" }


### PR DESCRIPTION
## Summary

- Adds `pegasus server create` command that provisions a Hetzner Cloud server
- Auto-detects SSH keys from `~/.ssh/`, uploads to Hetzner if needed
- Stores Hetzner API token in `~/.pegasus/hetzner_credentials` (same pattern as Pegasus API key)
- Optionally updates `config/deploy.yml` with the new server IP for Kamal deployments
- Bumps Python requirement from 3.9 to 3.10 (3.9 is EOL)

### Usage

```
pegasus server create my-app-production
pegasus server create my-app --server-type cx32 --location fsn1 --image ubuntu-22.04
```

### New dependencies

- `hcloud` — official Hetzner Cloud Python SDK
- `pyyaml` — already a transitive dep via cookiecutter, now explicit

## Test plan

- [x] 46 tests passing (14 new)
- [ ] Manual test with real Hetzner token — create server, verify SSH access
- [ ] Verify Kamal config auto-update with a real Pegasus project
- [ ] Test the token prompt flow end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)