### PR TITLE
add `--install` flag to startapp

### DIFF
--- a/pegasus_cli/startapp.py
+++ b/pegasus_cli/startapp.py
@@ -1,3 +1,4 @@
+import ast
 import pathlib
 import yaml
 
@@ -41,6 +42,138 @@ def load_config(ctx, param, value):
             return config
     except Exception as e:
         raise click.BadParameter(f"Error loading config file: {str(e)}")
+
+
+def find_settings_from_manage_py(manage_py_path: pathlib.Path) -> "pathlib.Path | None":
+    """Parse manage.py with ast and return the path to the settings file.
+
+    Handles two common patterns:
+      os.environ.setdefault("DJANGO_SETTINGS_MODULE", "myproject.settings")
+      os.environ["DJANGO_SETTINGS_MODULE"] = "myproject.settings"
+
+    Returns the resolved Path if the file exists, otherwise None.
+    """
+    try:
+        source = manage_py_path.read_text()
+        tree = ast.parse(source)
+    except (OSError, SyntaxError):
+        return None
+
+    module_name = None
+    for node in ast.walk(tree):
+        # os.environ.setdefault("DJANGO_SETTINGS_MODULE", "myproject.settings")
+        if (
+            isinstance(node, ast.Expr)
+            and isinstance(node.value, ast.Call)
+            and isinstance(node.value.func, ast.Attribute)
+            and node.value.func.attr == "setdefault"
+            and isinstance(node.value.func.value, ast.Attribute)
+            and node.value.func.value.attr == "environ"
+            and len(node.value.args) == 2
+            and isinstance(node.value.args[0], ast.Constant)
+            and node.value.args[0].value == "DJANGO_SETTINGS_MODULE"
+            and isinstance(node.value.args[1], ast.Constant)
+        ):
+            module_name = node.value.args[1].value
+            break
+
+        # os.environ["DJANGO_SETTINGS_MODULE"] = "myproject.settings"
+        if (
+            isinstance(node, ast.Assign)
+            and len(node.targets) == 1
+            and isinstance(node.targets[0], ast.Subscript)
+            and isinstance(node.targets[0].value, ast.Attribute)
+            and node.targets[0].value.attr == "environ"
+            and isinstance(node.targets[0].slice, ast.Constant)
+            and node.targets[0].slice.value == "DJANGO_SETTINGS_MODULE"
+            and isinstance(node.value, ast.Constant)
+        ):
+            module_name = node.value.value
+            break
+
+    if not module_name:
+        return None
+
+    settings_path = manage_py_path.parent / pathlib.Path(
+        module_name.replace(".", "/")
+    ).with_suffix(".py")
+    return settings_path if settings_path.exists() else None
+
+
+def add_to_installed_apps(settings_path: str, app_config: str) -> bool:
+    """Add app_config to INSTALLED_APPS (or PROJECT_APPS) in the given settings file.
+
+    Uses the ast library to locate the list and inserts the new entry before the
+    closing bracket.  Returns True if the entry was inserted, False if no suitable
+    list assignment was found.
+    """
+    path = pathlib.Path(settings_path)
+    source = path.read_text()
+    tree = ast.parse(source)
+
+    for var_name in ("PROJECT_APPS", "INSTALLED_APPS"):
+        list_node = _find_list_assignment(tree, var_name)
+        if list_node is not None:
+            modified = _insert_into_ast_list(source, list_node, f'"{app_config}"')
+            path.write_text(modified)
+            return True
+
+    return False
+
+
+def add_to_urlpatterns(
+    urls_path: str, app_name: str, app_module_path: str, use_teams: bool
+) -> bool:
+    """Add a path() entry for the new app to urlpatterns (or team_urlpatterns) in urls_path.
+
+    Returns True if the entry was inserted, False if no suitable list assignment was found.
+    """
+    path = pathlib.Path(urls_path)
+    source = path.read_text()
+    tree = ast.parse(source)
+
+    var_name = "team_urlpatterns" if use_teams else "urlpatterns"
+    list_node = _find_list_assignment(tree, var_name)
+    if list_node is None:
+        return False
+
+    entry = f'path("{app_name}/", include("{app_module_path}.urls"))'
+    modified = _insert_into_ast_list(source, list_node, entry)
+    path.write_text(modified)
+    return True
+
+
+def _find_list_assignment(tree: ast.Module, var_name: str) -> "ast.List | None":
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name) and target.id == var_name:
+                    if isinstance(node.value, ast.List):
+                        return node.value
+    return None
+
+
+def _insert_into_ast_list(source: str, list_node: ast.List, entry: str) -> str:
+    """Insert entry (raw text) as a new element into the list, before the closing ']'."""
+    lines = source.splitlines(keepends=True)
+    end_line_idx = list_node.end_lineno - 1  # 0-indexed
+    end_col = list_node.end_col_offset  # column index right after ']'
+    line = lines[end_line_idx]
+
+    if list_node.lineno == list_node.end_lineno:
+        # Single-line list: insert before ']'
+        sep = ", " if list_node.elts else ""
+        lines[end_line_idx] = (
+            line[: end_col - 1] + f"{sep}{entry}" + line[end_col - 1 :]
+        )
+    else:
+        # Multi-line list: insert a new line before the line containing ']'
+        bracket_indent = line[: end_col - 1]
+        item_indent = bracket_indent + "    "
+        new_line = f"{item_indent}{entry},\n"
+        lines[end_line_idx] = new_line + line
+
+    return "".join(lines)
 
 
 @click.command(name="startapp")
@@ -88,6 +221,23 @@ def load_config(ctx, param, value):
     default=None,
     help="Fully-qualified base model class for the app's models, e.g. apps.utils.models.BaseModel",
 )
+@click.option(
+    "--django-settings",
+    envvar="PEGASUS_DJANGO_SETTINGS",
+    type=click.Path(exists=True, dir_okay=False, resolve_path=True),
+    default=None,
+    help="Path to Django settings.py to automatically add the app to INSTALLED_APPS",
+)
+@click.option(
+    "--install",
+    is_flag=True,
+    default=False,
+    help=(
+        "Add the new app to settings.py and include its urls in the main urls.py. "
+        "Unless --django-settings is specified, it will be automatically extracted from "
+        "manage.py in the current directory."
+    ),
+)
 def startapp(
     name,
     model_names,
@@ -96,6 +246,8 @@ def startapp(
     module_path,
     template_directory,
     base_model: str | None = None,
+    django_settings: str | None = None,
+    install: bool = False,
 ):
     """Creates a Django app directory structure for the given app name in
     the current directory or optionally in the given directory.
@@ -108,6 +260,20 @@ def startapp(
     app_directory = config.get("app_directory", app_directory)
     module_path = config.get("module_path", module_path)
     base_model = config.get("base_model", base_model)
+    install = config.get("install", install)
+    django_settings = (
+        config.get("django_settings", django_settings) if install else None
+    )
+    if install and not django_settings:
+        manage_py = pathlib.Path.cwd() / "manage.py"
+        resolved = find_settings_from_manage_py(manage_py)
+        if resolved:
+            django_settings = str(resolved)
+        else:
+            click.echo(
+                "Warning: --install was set but could not determine settings file from manage.py",
+                err=True,
+            )
     if base_model:
         base_model_module, base_model_class = base_model.rsplit(".", 1)
     else:
@@ -175,6 +341,20 @@ def startapp(
 
     run_ruff_format(app_dir)
 
+    app_config_string = f"{app_module_path}.apps.{context['camel_case_app_name']}Config"
+    settings_updated = False
+    urls_updated = False
+    if django_settings:
+        settings_updated = add_to_installed_apps(django_settings, app_config_string)
+        urls_path = pathlib.Path(django_settings).parent / "urls.py"
+        if urls_path.exists():
+            urls_updated = add_to_urlpatterns(
+                str(urls_path), name, app_module_path, use_teams
+            )
+
+    context["app_config_string"] = app_config_string
+    context["settings_updated"] = settings_updated
+    context["urls_updated"] = urls_updated
     env = get_template_env()
     output = env.get_template("internal/cli_output.txt").render(context)
     print(output)

--- a/pegasus_cli/templates/internal/cli_output.txt
+++ b/pegasus_cli/templates/internal/cli_output.txt
@@ -6,6 +6,9 @@ Templates: << template_dir >>
 Models: << model_names | join(", ") >>
 <%- endif %>
 
+<%- if urls_updated %>
+path("<< app_name >>/", include("<< app_module_path >>.urls")) was automatically added to your main urls.py.
+<%- else %>
 As next steps, you should add the following to your main urls.py:
 
 <% if use_teams %>team_<% endif %>urlpatterns = [
@@ -13,12 +16,16 @@ As next steps, you should add the following to your main urls.py:
     path("<< app_name >>/", include("<< app_module_path >>.urls")),
     ...
 ]
-
+<%- endif %>
+<%- if settings_updated %>
+<< app_config_string >> was automatically added to your installed apps.
+<%- else %>
 And update your installed apps in settings.py:
 
 PROJECT_APPS = [
     ...
-    "<< app_module_path >>.apps.<< camel_case_app_name >>Config",
+    "<< app_config_string >>",
 ]
+<%- endif %>
 
 Happy coding!

--- a/tests/test_install_app.py
+++ b/tests/test_install_app.py
@@ -1,0 +1,389 @@
+import pathlib
+import textwrap
+
+from pegasus_cli.startapp import (
+    add_to_installed_apps,
+    add_to_urlpatterns,
+    find_settings_from_manage_py,
+)
+
+APP_CONFIG = "myapp.apps.MyappConfig"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def write_settings(tmp_path: pathlib.Path, content: str) -> pathlib.Path:
+    settings = tmp_path / "settings.py"
+    settings.write_text(textwrap.dedent(content))
+    return settings
+
+
+def installed_apps_contents(settings: pathlib.Path) -> list[str]:
+    """Evaluate the settings file and return the INSTALLED_APPS list."""
+    ns: dict = {}
+    exec(settings.read_text(), ns)
+    return ns["INSTALLED_APPS"]
+
+
+# ---------------------------------------------------------------------------
+# Direct INSTALLED_APPS list
+# ---------------------------------------------------------------------------
+
+
+def test_installed_apps_multiline(tmp_path):
+    settings = write_settings(
+        tmp_path,
+        """
+        INSTALLED_APPS = [
+            "django.contrib.auth",
+            "django.contrib.contenttypes",
+        ]
+    """,
+    )
+
+    result = add_to_installed_apps(str(settings), APP_CONFIG)
+
+    assert result is True
+    assert APP_CONFIG in settings.read_text()
+    apps = installed_apps_contents(settings)
+    assert apps[-1] == APP_CONFIG
+
+
+def test_installed_apps_single_line(tmp_path):
+    settings = write_settings(
+        tmp_path,
+        """
+        INSTALLED_APPS = ["django.contrib.auth", "django.contrib.contenttypes"]
+    """,
+    )
+
+    result = add_to_installed_apps(str(settings), APP_CONFIG)
+
+    assert result is True
+    apps = installed_apps_contents(settings)
+    assert APP_CONFIG in apps
+
+
+def test_installed_apps_empty_list(tmp_path):
+    settings = write_settings(
+        tmp_path,
+        """
+        INSTALLED_APPS = []
+    """,
+    )
+
+    result = add_to_installed_apps(str(settings), APP_CONFIG)
+
+    assert result is True
+    apps = installed_apps_contents(settings)
+    assert apps == [APP_CONFIG]
+
+
+# ---------------------------------------------------------------------------
+# PROJECT_APPS pattern (Pegasus style)
+# ---------------------------------------------------------------------------
+
+
+def test_project_apps_multiline(tmp_path):
+    """PROJECT_APPS is preferred over INSTALLED_APPS when both are present."""
+    settings = write_settings(
+        tmp_path,
+        """
+        DJANGO_APPS = [
+            "django.contrib.auth",
+            "django.contrib.contenttypes",
+        ]
+
+        PROJECT_APPS = [
+            "apps.users",
+        ]
+
+        INSTALLED_APPS = DJANGO_APPS + PROJECT_APPS
+    """,
+    )
+
+    result = add_to_installed_apps(str(settings), APP_CONFIG)
+
+    assert result is True
+    text = settings.read_text()
+    assert APP_CONFIG in text
+
+    # The entry must be inside PROJECT_APPS, not DJANGO_APPS
+    project_block_start = text.index("PROJECT_APPS")
+    installed_block_start = text.index("INSTALLED_APPS")
+    entry_pos = text.index(APP_CONFIG)
+    assert project_block_start < entry_pos < installed_block_start
+
+
+def test_project_apps_only(tmp_path):
+    settings = write_settings(
+        tmp_path,
+        """
+        DJANGO_APPS = [
+            "django.contrib.auth",
+        ]
+
+        PROJECT_APPS = [
+            "apps.users",
+        ]
+
+        INSTALLED_APPS = DJANGO_APPS + PROJECT_APPS
+    """,
+    )
+
+    result = add_to_installed_apps(str(settings), APP_CONFIG)
+
+    assert result is True
+    # Evaluate combined INSTALLED_APPS to confirm the entry is reachable
+    ns: dict = {}
+    exec(settings.read_text(), ns)
+    assert APP_CONFIG in ns["INSTALLED_APPS"]
+
+
+# ---------------------------------------------------------------------------
+# Edge / failure cases
+# ---------------------------------------------------------------------------
+
+
+def test_no_installed_apps_returns_false(tmp_path):
+    settings = write_settings(
+        tmp_path,
+        """
+        DEBUG = True
+        DATABASES = {}
+    """,
+    )
+
+    result = add_to_installed_apps(str(settings), APP_CONFIG)
+
+    assert result is False
+    assert APP_CONFIG not in settings.read_text()
+
+
+def test_file_not_modified_when_no_list_found(tmp_path):
+    content = textwrap.dedent(
+        """
+        DEBUG = True
+    """
+    )
+    settings = write_settings(tmp_path, content)
+    original = settings.read_text()
+
+    add_to_installed_apps(str(settings), APP_CONFIG)
+
+    assert settings.read_text() == original
+
+
+def test_other_file_content_preserved(tmp_path):
+    settings = write_settings(
+        tmp_path,
+        """
+        SECRET_KEY = "abc123"
+
+        INSTALLED_APPS = [
+            "django.contrib.auth",
+        ]
+
+        DATABASES = {"default": {"ENGINE": "django.db.backends.sqlite3"}}
+    """,
+    )
+
+    add_to_installed_apps(str(settings), APP_CONFIG)
+
+    text = settings.read_text()
+    assert "SECRET_KEY" in text
+    assert "DATABASES" in text
+
+
+# ---------------------------------------------------------------------------
+# find_settings_from_manage_py
+# ---------------------------------------------------------------------------
+
+
+def write_manage_py(tmp_path: pathlib.Path, content: str) -> pathlib.Path:
+    manage = tmp_path / "manage.py"
+    manage.write_text(textwrap.dedent(content))
+    return manage
+
+
+def make_settings_file(tmp_path: pathlib.Path, module: str) -> pathlib.Path:
+    """Create an empty settings file at the location implied by the module name."""
+    rel = pathlib.Path(module.replace(".", "/")).with_suffix(".py")
+    path = tmp_path / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("# settings\n")
+    return path
+
+
+def test_find_settings_setdefault(tmp_path):
+    make_settings_file(tmp_path, "myproject.settings")
+    manage = write_manage_py(
+        tmp_path,
+        """
+        import os
+        import sys
+
+        def main():
+            os.environ.setdefault("DJANGO_SETTINGS_MODULE", "myproject.settings")
+
+        if __name__ == "__main__":
+            main()
+    """,
+    )
+
+    result = find_settings_from_manage_py(manage)
+
+    assert result is not None
+    assert result == tmp_path / "myproject" / "settings.py"
+
+
+def test_find_settings_direct_assignment(tmp_path):
+    make_settings_file(tmp_path, "myproject.settings.local")
+    manage = write_manage_py(
+        tmp_path,
+        """
+        import os
+        os.environ["DJANGO_SETTINGS_MODULE"] = "myproject.settings.local"
+    """,
+    )
+
+    result = find_settings_from_manage_py(manage)
+
+    assert result is not None
+    assert result == tmp_path / "myproject" / "settings" / "local.py"
+
+
+def test_find_settings_returns_none_when_not_set(tmp_path):
+    manage = write_manage_py(
+        tmp_path,
+        """
+        import os
+        def main():
+            pass
+    """,
+    )
+
+    assert find_settings_from_manage_py(manage) is None
+
+
+def test_find_settings_returns_none_when_file_missing(tmp_path):
+    """Module name found in manage.py but settings file doesn't exist on disk."""
+    manage = write_manage_py(
+        tmp_path,
+        """
+        import os
+        os.environ.setdefault("DJANGO_SETTINGS_MODULE", "nonexistent.settings")
+    """,
+    )
+
+    assert find_settings_from_manage_py(manage) is None
+
+
+def test_find_settings_returns_none_for_missing_manage_py(tmp_path):
+    assert find_settings_from_manage_py(tmp_path / "manage.py") is None
+
+
+# ---------------------------------------------------------------------------
+# add_to_urlpatterns
+# ---------------------------------------------------------------------------
+
+
+def write_urls(tmp_path: pathlib.Path, content: str) -> pathlib.Path:
+    urls = tmp_path / "urls.py"
+    urls.write_text(textwrap.dedent(content))
+    return urls
+
+
+def test_urlpatterns_multiline(tmp_path):
+    urls = write_urls(
+        tmp_path,
+        """
+        from django.urls import path, include
+
+        urlpatterns = [
+            path("admin/", admin.site.urls),
+        ]
+    """,
+    )
+
+    result = add_to_urlpatterns(str(urls), "golf", "apps.golf", use_teams=False)
+
+    assert result is True
+    text = urls.read_text()
+    assert 'path("golf/", include("apps.golf.urls"))' in text
+    # Verify existing entry is preserved
+    assert 'path("admin/", admin.site.urls)' in text
+
+
+def test_urlpatterns_empty_list(tmp_path):
+    urls = write_urls(
+        tmp_path,
+        """
+        from django.urls import path
+
+        urlpatterns = []
+    """,
+    )
+
+    result = add_to_urlpatterns(str(urls), "golf", "apps.golf", use_teams=False)
+
+    assert result is True
+    assert 'path("golf/", include("apps.golf.urls"))' in urls.read_text()
+
+
+def test_team_urlpatterns(tmp_path):
+    urls = write_urls(
+        tmp_path,
+        """
+        from django.urls import path, include
+
+        team_urlpatterns = [
+            path("dashboard/", views.dashboard),
+        ]
+    """,
+    )
+
+    result = add_to_urlpatterns(str(urls), "golf", "apps.golf", use_teams=True)
+
+    assert result is True
+    text = urls.read_text()
+    assert 'path("golf/", include("apps.golf.urls"))' in text
+    # Entry must be inside team_urlpatterns block
+    team_block_start = text.index("team_urlpatterns")
+    entry_pos = text.index('path("golf/"')
+    assert entry_pos > team_block_start
+
+
+def test_urlpatterns_not_found_returns_false(tmp_path):
+    urls = write_urls(
+        tmp_path,
+        """
+        # empty urls file
+        from django.urls import path
+    """,
+    )
+
+    result = add_to_urlpatterns(str(urls), "golf", "apps.golf", use_teams=False)
+
+    assert result is False
+
+
+def test_use_teams_false_ignores_team_urlpatterns(tmp_path):
+    """With use_teams=False, only urlpatterns is targeted, not team_urlpatterns."""
+    urls = write_urls(
+        tmp_path,
+        """
+        from django.urls import path, include
+
+        team_urlpatterns = [
+            path("dashboard/", views.dashboard),
+        ]
+    """,
+    )
+
+    result = add_to_urlpatterns(str(urls), "golf", "apps.golf", use_teams=False)
+
+    assert result is False


### PR DESCRIPTION
This is something I've been wanting ever since I first tried the pegasus cli.

The patchset adds a new `--install` flag to the startapp command. If specified, it will either look for the settings module name in a `manage.py` file within the current directory or look for the value of `--django-settings` if specified.

It uses the stdlib `ast` library to parse settings. If it finds PROJECT_APPS, it adds the new app to the end of that list. Otherwise if it finds INSTALLED_APPS it appends it to that.

It also adds an entry `appname/` to either team_urlpatterns or urlpatterns in the urls.py in the same package as settings.py.