### PR TITLE
Add --pr-title option to projects push

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,12 @@ To upgrade to the latest development build instead of the stable release:
 pegasus projects push <project_id> --upgrade --dev
 ```
 
+To set a custom pull request title (used when a PR is created):
+
+```bash
+pegasus projects push <project_id> --upgrade --pr-title "Upgrade Pegasus to 2025.2"
+```
+
 The CLI will show progress as the build runs and print the pull request or repository URL when complete.
 
 ### Custom server URL

--- a/pegasus_cli/api_client.py
+++ b/pegasus_cli/api_client.py
@@ -49,12 +49,15 @@ class PegasusClient:
         project_id: int,
         upgrade_to_latest: bool = False,
         release_channel: str = "stable",
+        pr_title: str | None = None,
     ) -> dict:
         payload = {}
         if upgrade_to_latest:
             payload["upgrade_to_latest"] = True
             if release_channel != "stable":
                 payload["release_channel"] = release_channel
+        if pr_title:
+            payload["pr_title"] = pr_title
         response = self.session.post(
             self._url(f"{project_id}/push-to-github/"),
             json=payload,

--- a/pegasus_cli/projects.py
+++ b/pegasus_cli/projects.py
@@ -104,8 +104,13 @@ def list_projects(ctx):
     default=False,
     help="Use the dev release channel (implies --upgrade).",
 )
+@click.option(
+    "--pr-title",
+    default=None,
+    help="Custom title for the pull request (applies when a PR is created).",
+)
 @click.pass_context
-def push(ctx, project_id, upgrade, dev):
+def push(ctx, project_id, upgrade, dev, pr_title):
     """Push a project to GitHub.
 
     If PROJECT_ID is not given, lists your projects and prompts you to choose one.
@@ -132,7 +137,10 @@ def push(ctx, project_id, upgrade, dev):
         # Trigger the push
         click.echo("Triggering push to GitHub...")
         result = client.push_to_github(
-            project_id, upgrade_to_latest=upgrade, release_channel=release_channel
+            project_id,
+            upgrade_to_latest=upgrade,
+            release_channel=release_channel,
+            pr_title=pr_title,
         )
         task_id = result["task_id"]
         version = result.get("pegasus_version", "unknown")

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -62,6 +62,21 @@ class TestPushToGithub:
         call_kwargs = client.session.post.call_args
         assert call_kwargs.kwargs["json"] == {"upgrade_to_latest": True}
 
+    def test_with_pr_title(self, client):
+        client.session.post = MagicMock(return_value=_mock_response(202, {}))
+        client.push_to_github(1, upgrade_to_latest=True, pr_title="My custom title")
+        call_kwargs = client.session.post.call_args
+        assert call_kwargs.kwargs["json"] == {
+            "upgrade_to_latest": True,
+            "pr_title": "My custom title",
+        }
+
+    def test_pr_title_without_upgrade(self, client):
+        client.session.post = MagicMock(return_value=_mock_response(202, {}))
+        client.push_to_github(1, pr_title="My custom title")
+        call_kwargs = client.session.post.call_args
+        assert call_kwargs.kwargs["json"] == {"pr_title": "My custom title"}
+
     def test_bad_request(self, client):
         error_resp = _mock_response(400, {"error": "No GitHub repository configured."})
         client.session.post = MagicMock(return_value=error_resp)

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -114,7 +114,7 @@ class TestProjectsPush:
         assert result.exit_code == 0
         assert "Pull request created" in result.output
         client.push_to_github.assert_called_once_with(
-            42, upgrade_to_latest=False, release_channel="stable"
+            42, upgrade_to_latest=False, release_channel="stable", pr_title=None
         )
 
     @patch("pegasus_cli.projects._get_client")
@@ -126,7 +126,7 @@ class TestProjectsPush:
         assert result.exit_code == 0
         assert "Upgrade options" in result.output
         client.push_to_github.assert_called_once_with(
-            42, upgrade_to_latest=True, release_channel="stable"
+            42, upgrade_to_latest=True, release_channel="stable", pr_title=None
         )
 
     @patch("pegasus_cli.projects._get_client")
@@ -137,7 +137,7 @@ class TestProjectsPush:
         result = runner.invoke(cli, ["projects", "push", "42"], input="2\n")
         assert result.exit_code == 0
         client.push_to_github.assert_called_once_with(
-            42, upgrade_to_latest=True, release_channel="dev"
+            42, upgrade_to_latest=True, release_channel="dev", pr_title=None
         )
 
     @patch("pegasus_cli.projects._get_client")
@@ -148,7 +148,7 @@ class TestProjectsPush:
         result = runner.invoke(cli, ["projects", "push", "42", "--upgrade"])
         assert result.exit_code == 0
         client.push_to_github.assert_called_once_with(
-            42, upgrade_to_latest=True, release_channel="stable"
+            42, upgrade_to_latest=True, release_channel="stable", pr_title=None
         )
 
     @patch("pegasus_cli.projects._get_client")
@@ -159,7 +159,7 @@ class TestProjectsPush:
         result = runner.invoke(cli, ["projects", "push", "42", "--dev"])
         assert result.exit_code == 0
         client.push_to_github.assert_called_once_with(
-            42, upgrade_to_latest=True, release_channel="dev"
+            42, upgrade_to_latest=True, release_channel="dev", pr_title=None
         )
 
     @patch("pegasus_cli.projects._get_client")
@@ -185,7 +185,31 @@ class TestProjectsPush:
         result = runner.invoke(cli, ["projects", "push"], input="2\n3\n")
         assert result.exit_code == 0
         client.push_to_github.assert_called_once_with(
-            20, upgrade_to_latest=False, release_channel="stable"
+            20, upgrade_to_latest=False, release_channel="stable", pr_title=None
+        )
+
+    @patch("pegasus_cli.projects._get_client")
+    def test_push_with_pr_title(self, mock_get_client):
+        client = _mock_client()
+        mock_get_client.return_value = client
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "projects",
+                "push",
+                "42",
+                "--upgrade",
+                "--pr-title",
+                "Upgrade Pegasus to 2025.2",
+            ],
+        )
+        assert result.exit_code == 0
+        client.push_to_github.assert_called_once_with(
+            42,
+            upgrade_to_latest=True,
+            release_channel="stable",
+            pr_title="Upgrade Pegasus to 2025.2",
         )
 
     @patch("pegasus_cli.projects._get_client")


### PR DESCRIPTION
Threads an optional pr_title through to the push-to-github API so users can set a custom pull request title when the server creates a PR.