### PR TITLE
Show license tier in the projects list instead of a licensed checkmark

### DIFF
--- a/pegasus_cli/projects.py
+++ b/pegasus_cli/projects.py
@@ -529,16 +529,18 @@ def _build_projects_table(project_list: list[dict], numbered: bool = False) -> T
     table.add_column("ID", style="cyan", justify="right")
     table.add_column("Name", style="bold", max_width=50)
     table.add_column("Version")
-    table.add_column("Licensed", justify="center")
+    table.add_column("License", justify="center")
     table.add_column("GitHub", justify="center")
 
     for i, p in enumerate(project_list, 1):
         version = p.get("pegasus_version") or "unknown"
         if p.get("use_latest_version"):
             version += " (latest)"
-        license_icon = "\u2705" if p.get("has_valid_license") else "\u274c"
+        license_display = p.get("license_display") or (
+            "\u2705" if p.get("has_valid_license") else "\u274c"
+        )
         github_icon = "\u2705" if p.get("has_github_repo") else "\u274c"
-        row = [str(p["id"]), p["name"], version, license_icon, github_icon]
+        row = [str(p["id"]), p["name"], version, license_display, github_icon]
         if numbered:
             row.insert(0, str(i))
         table.add_row(*row)

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -107,6 +107,7 @@ class TestProjectsList:
                     "pegasus_version": "2025.1",
                     "has_github_repo": True,
                     "has_valid_license": True,
+                    "license_display": "Professional",
                 },
             ]
         )
@@ -115,7 +116,45 @@ class TestProjectsList:
         assert result.exit_code == 0
         assert "My App" in result.output
         assert "2025.1" in result.output
-        assert "\u2705" in result.output
+        assert "Professional" in result.output
+        assert "\u2705" in result.output  # GitHub column
+
+    @patch("pegasus_cli.projects._get_client")
+    def test_list_shows_free_license(self, mock_get_client):
+        mock_get_client.return_value = _mock_client(
+            projects=[
+                {
+                    "id": 1,
+                    "name": "Free App",
+                    "pegasus_version": "2026.7",
+                    "has_github_repo": False,
+                    "has_valid_license": True,
+                    "license_display": "Free",
+                },
+            ]
+        )
+        runner = CliRunner()
+        result = runner.invoke(cli, ["projects", "list"])
+        assert result.exit_code == 0
+        assert "Free" in result.output
+
+    @patch("pegasus_cli.projects._get_client")
+    def test_list_falls_back_to_icons_without_license_display(self, mock_get_client):
+        mock_get_client.return_value = _mock_client(
+            projects=[
+                {
+                    "id": 1,
+                    "name": "Old Server App",
+                    "pegasus_version": "2025.1",
+                    "has_github_repo": True,
+                    "has_valid_license": False,
+                },
+            ]
+        )
+        runner = CliRunner()
+        result = runner.invoke(cli, ["projects", "list"])
+        assert result.exit_code == 0
+        assert "\u274c" in result.output
 
     @patch("pegasus_cli.projects._get_client")
     def test_list_shows_latest_version(self, mock_get_client):


### PR DESCRIPTION
## What

Free-tier projects showed as "not licensed" (❌) in `pegasus projects` even though they build and push fine. The server now sends a `license_display` field (czue/pegasus-site#343); this renders it in a "License" column (Free / Starter / Professional / Unlimited / Invalid), falling back to the old ✅/❌ icons if the field is absent (e.g. CLI released before the server deploy).

## Testing

- `tests/test_projects.py` updated + new cases for the Free display and the icon fallback; all 45 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)