### PR TITLE
Reframe README around managing Pegasus projects from the terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,32 +5,32 @@
 [![Tests](https://github.com/saaspegasus/cli/actions/workflows/test.yml/badge.svg)](https://github.com/saaspegasus/cli/actions/workflows/test.yml)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://github.com/saaspegasus/cli/blob/master/LICENSE)
 
-
-## Demo
-
-A demo is worth 1,000 words. Click the image below to see the Pegasus CLI in action:
-
-[![Pegasus CLI Demo](https://img.youtube.com/vi/wKS_bbD5RVs/0.jpg)](https://www.youtube.com/watch?v=wKS_bbD5RVs)
-
 ## Overview
 
-The Pegasus CLI is a command-line tool that streamlines the process of working in a Django project.
-It is currently designed to work with the [SaaS Pegasus Django boilerplate](https://www.saaspegasus.com/),
-but can be used more generally for any Django project (and will be updated to work with generic
-Django projects in the future).
+The Pegasus CLI is the command-line companion to [SaaS Pegasus](https://www.saaspegasus.com/):
+manage your Pegasus projects without leaving the terminal.
 
-It is currently geared around the `startapp` command. This will create a new app in your Django project,
-and (optionally) spin up an entire Create / Update / Delete (CRUD) interface for it, built with
-Django forms and HTMX.
+With it you can:
 
-Example usage:
+- **Create and configure projects** — everything you can do in the web UI:
+  `pegasus projects create`, `pegasus projects update`, with every project setting scriptable.
+- **Push your codebase to GitHub** — `pegasus projects push` builds your project and
+  opens a pull request (or creates the repo) for you.
+- **Upgrade Pegasus versions** — `pegasus projects push --upgrade` bumps your project
+  to the latest release as part of the push.
+- **Generate code locally** — `pegasus startapp` scaffolds a new Django app with an
+  optional HTMX-powered CRUD interface.
+
+Because every command works non-interactively (`--set`, `--json`, `--no-upgrade`), the
+CLI also works well in scripts, CI, and AI agent workflows.
+
+A minimal end-to-end session:
 
 ```bash
-pegasus startapp todos Project Todo
+pegasus auth
+pegasus projects create --set project_name="My App" --set project_slug=my_app
+pegasus projects push
 ```
-
-This will create a `todos` app in your Django project with models, URLs, views and templates to
-work with a `Project` and `Todo` model.
 
 ## Installation
 
@@ -38,6 +38,7 @@ Install this tool using `pip`:
 ```bash
 pip install pegasus-cli
 ```
+
 ## Usage
 
 For help, run:
@@ -48,71 +49,8 @@ You can also use:
 ```bash
 python -m pegasus --help
 ```
-## Configuration
 
-You can run `pegasus startapp --help` for configuration options.
-In addition to the command-line options, you can also set default values for configuration
-options by creating a `pegasus-config.yaml` file in your project directory.
-The format of the file is:
-
-```yaml
-cli:
-  app_directory: apps
-  module_path: apps
-  template_directory: templates
-  base_model: apps.teams.models.BaseTeamModel
-  use_teams: true
-  django_settings: myproject/settings.py  # optional, auto-detected from manage.py by default
-```
-
-The above configuration is the recommended configuration for SaaS Pegasus projects
-(with teams turned on, else set `use_teams: false` and `base_model: apps.utils.models.BaseModel`).
-
-A recommended default configuration for your project will be included in your project's `pegasus-config.yaml`
-file if you are on Pegasus version 2024.9 or later.
-
-The Pegasus config will create your apps in the `apps` directory, and will use the `templates` directory for your templates.
-
-## Automatic App Installation
-
-When you run `pegasus startapp`, the CLI will automatically try to add the new app to your
-Django project's `settings.py` and `urls.py` files. It does this by:
-
-1. Parsing `manage.py` in the current directory to find your `DJANGO_SETTINGS_MODULE`.
-2. Adding the app's `AppConfig` to `PROJECT_APPS` (preferred) or `INSTALLED_APPS` in your settings file.
-3. Adding a `path()` entry to `urlpatterns` (or `team_urlpatterns` if using teams) in the
-   `urls.py` file next to your settings.
-
-If the CLI can't find `manage.py` or your settings file, it will fall back to printing
-manual instructions instead.
-
-You can also specify the settings file explicitly:
-
-```bash
-pegasus startapp todos --django-settings myproject/settings.py
-```
-
-## Migrating pg- CSS classes
-
-If you're upgrading a Pegasus project that previously used the legacy `pg-` prefixed
-CSS classes (e.g. `pg-button`, `pg-card`), you can run:
-
-```bash
-pegasus migrate-css
-```
-
-from your project root to replace them with their native Tailwind/DaisyUI equivalents
-in your templates and JavaScript files. The class mappings are read from your
-project's `assets/styles/pegasus/tailwind.css` so they always match the version of
-Pegasus your project was built with.
-
-Use `--dry-run` to preview changes without modifying files. For non-standard
-project layouts, `--css-file` and `--search-dir` (repeatable) let you point at
-alternate paths.
-
-## Pushing to GitHub
-
-You can use the CLI to push your Pegasus project to GitHub directly from the command line.
+## Managing your Pegasus projects
 
 ### Setup
 
@@ -237,6 +175,88 @@ To use a different server, pass `--base-url` or set `PEGASUS_BASE_URL`:
 ```bash
 pegasus projects --base-url https://your-server.com list
 ```
+
+## Creating Django apps
+
+The `pegasus startapp` command creates a new app in your Django project,
+and (optionally) spins up an entire Create / Update / Delete (CRUD) interface
+for it, built with Django forms and HTMX. It is designed for Pegasus projects,
+but can be used more generally for any Django project.
+
+Example usage:
+
+```bash
+pegasus startapp todos Project Todo
+```
+
+This will create a `todos` app in your Django project with models, URLs, views and templates to
+work with a `Project` and `Todo` model.
+
+A demo is worth 1,000 words. Click the image below to see it in action:
+
+[![Pegasus CLI Demo](https://img.youtube.com/vi/wKS_bbD5RVs/0.jpg)](https://www.youtube.com/watch?v=wKS_bbD5RVs)
+
+### Configuration
+
+You can run `pegasus startapp --help` for configuration options.
+In addition to the command-line options, you can also set default values for configuration
+options by creating a `pegasus-config.yaml` file in your project directory.
+The format of the file is:
+
+```yaml
+cli:
+  app_directory: apps
+  module_path: apps
+  template_directory: templates
+  base_model: apps.teams.models.BaseTeamModel
+  use_teams: true
+  django_settings: myproject/settings.py  # optional, auto-detected from manage.py by default
+```
+
+The above configuration is the recommended configuration for SaaS Pegasus projects
+(with teams turned on, else set `use_teams: false` and `base_model: apps.utils.models.BaseModel`).
+
+A recommended default configuration for your project will be included in your project's `pegasus-config.yaml`
+file if you are on Pegasus version 2024.9 or later.
+
+The Pegasus config will create your apps in the `apps` directory, and will use the `templates` directory for your templates.
+
+### Automatic App Installation
+
+When you run `pegasus startapp`, the CLI will automatically try to add the new app to your
+Django project's `settings.py` and `urls.py` files. It does this by:
+
+1. Parsing `manage.py` in the current directory to find your `DJANGO_SETTINGS_MODULE`.
+2. Adding the app's `AppConfig` to `PROJECT_APPS` (preferred) or `INSTALLED_APPS` in your settings file.
+3. Adding a `path()` entry to `urlpatterns` (or `team_urlpatterns` if using teams) in the
+   `urls.py` file next to your settings.
+
+If the CLI can't find `manage.py` or your settings file, it will fall back to printing
+manual instructions instead.
+
+You can also specify the settings file explicitly:
+
+```bash
+pegasus startapp todos --django-settings myproject/settings.py
+```
+
+## Migrating pg- CSS classes
+
+If you're upgrading a Pegasus project that previously used the legacy `pg-` prefixed
+CSS classes (e.g. `pg-button`, `pg-card`), you can run:
+
+```bash
+pegasus migrate-css
+```
+
+from your project root to replace them with their native Tailwind/DaisyUI equivalents
+in your templates and JavaScript files. The class mappings are read from your
+project's `assets/styles/pegasus/tailwind.css` so they always match the version of
+Pegasus your project was built with.
+
+Use `--dry-run` to preview changes without modifying files. For non-standard
+project layouts, `--css-file` and `--search-dir` (repeatable) let you point at
+alternate paths.
 
 ## Development
 


### PR DESCRIPTION
The intro was still centered on startapp code generation from the CLI's original release. Lead with the platform integration instead (create / configure / push / upgrade projects), promote that section above the local tools, and group startapp (with its demo video and config docs) under its own section.